### PR TITLE
Fix RPC json marshalling

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1293,7 +1293,7 @@ type RPCTransaction struct {
 
 	// deposit-tx only
 	BlockHeight *hexutil.Uint64 `json:"blockHeight,omitempty"`
-	Mint        *hexutil.Big    `json:"big,omitempty"`
+	Mint        *hexutil.Big    `json:"mint,omitempty"`
 }
 
 // newRPCTransaction returns a transaction that will serialize to the RPC


### PR DESCRIPTION
**Description**
The mint field was not being reported on deposit transactions over
the JSON RPC interface because the field was misnamed.


