### PR TITLE
core: deposit txs block height check in block body validation

### DIFF
--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -63,13 +63,12 @@ func (v *BlockValidator) ValidateBody(block *types.Block) error {
 		return fmt.Errorf("uncle root hash mismatch: have %x, want %x", hash, header.UncleHash)
 	}
 	// deposits included their positional information for tx-hashing purposes.
-	// height := block.NumberU64()
+	height := block.NumberU64()
 	for i, tx := range block.Transactions() {
 		if tx.Type() == types.DepositTxType {
-			// TODO: Deposit Tx includes the height of the L1 block, not the L2 block
-			// if tx.BlockHeight() != height {
-			// 	return fmt.Errorf("deposit included in block with wrong block height: %d, expected %d", tx.BlockHeight(), height)
-			// }
+			if tx.BlockHeight() != height {
+				return fmt.Errorf("deposit included in block with wrong block height: %d, expected %d", tx.BlockHeight(), height)
+			}
 			if tx.TransactionIndex() != uint64(i) {
 				return fmt.Errorf("deposit included in block at wrong index: %d, expected %d", tx.TransactionIndex(), i)
 			}

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -289,6 +289,8 @@ func (tx *Transaction) To() *common.Address {
 	return copyAddressPtr(tx.inner.to())
 }
 
+// BlockHeight returns the L2 block height encoded in the deposit tx.
+// This returns 0 if this is not a deposit tx.
 func (tx *Transaction) BlockHeight() uint64 {
 	if dep, ok := tx.inner.(*DepositTx); ok {
 		return dep.BlockHeight
@@ -296,6 +298,8 @@ func (tx *Transaction) BlockHeight() uint64 {
 	return 0
 }
 
+// TransactionIndex returns the tx index encoded in the deposit tx.
+// This returns 0 if this is not a deposit tx.
 func (tx *Transaction) TransactionIndex() uint64 {
 	if dep, ok := tx.inner.(*DepositTx); ok {
 		return dep.TransactionIndex
@@ -303,6 +307,8 @@ func (tx *Transaction) TransactionIndex() uint64 {
 	return 0
 }
 
+// Mint returns the ETH to mint in the deposit tx.
+// This returns nil if there is nothing to mint, or if this is not a deposit tx.
 func (tx *Transaction) Mint() *big.Int {
 	if dep, ok := tx.inner.(*DepositTx); ok {
 		return dep.Mint

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff
 	github.com/go-ole/go-ole v1.2.1 // indirect
 	github.com/go-stack/stack v1.8.0
-	github.com/golang-jwt/jwt/v4 v4.3.0 // indirect
+	github.com/golang-jwt/jwt/v4 v4.3.0
 	github.com/golang/protobuf v1.4.3
 	github.com/golang/snappy v0.0.4
 	github.com/google/gofuzz v1.1.1-0.20200604201612-c04b05f3adfa

--- a/go.sum
+++ b/go.sum
@@ -154,8 +154,6 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/gofrs/uuid v3.3.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
-github.com/golang-jwt/jwt/v4 v4.2.0 h1:besgBTC8w8HjP6NzQdxwKH9Z5oQMZ24ThTrHp3cZ8eU=
-github.com/golang-jwt/jwt/v4 v4.2.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang-jwt/jwt/v4 v4.3.0 h1:kHL1vqdqWNfATmA0FNMdmZNMyZI1U6O31X4rlIPoBog=
 github.com/golang-jwt/jwt/v4 v4.3.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=


### PR DESCRIPTION
Check the block-height of a deposit-tx. Technically this is just a sanity-check, as the deposits are already validated by reproducing them on the consensus layer from L1 info (or optimistically accepted, and reorged if invalid later on).

Also adds doc comments to related functions, and `go mod tidy`