### PR TITLE
core: do not try to reinject deposit txs

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -1283,6 +1283,16 @@ func (pool *TxPool) reset(oldHead, newHead *types.Header) {
 						return
 					}
 				}
+				// Do not insert deposit txs back into the pool
+				// (validateTx would still catch it if not filtered, but no need to re-inject in the first place).
+				j := 0
+				for _, tx := range discarded {
+					if tx.Type() != types.DepositTxType {
+						discarded[j] = tx
+						j++
+					}
+				}
+				discarded = discarded[:j]
 				reinject = types.TxDifference(discarded, included)
 			}
 		}


### PR DESCRIPTION
Previously it would try to re-inject deposit txs of blocks that are reorged out, while these deposit txs were never supposed to be in the tx pool.

Previously `addTxsLocked` would call `add` for each, which runs `validateTx`, which then avoids the reinject but pollutes the metrics/trace-logs with logs for something that could have been avoided.

This should also make reorgs of empty blocks faster, as the `txSenderCacher` doesn't get hit with tasks for just deposit txs anymore.




