### PR TITLE
Provide gas to Call/Create in deposit transactions

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -220,6 +220,8 @@ func (st *StateTransition) preCheck() error {
 	if st.msg.Nonce() == types.DepositsNonce {
 		// No fee fields to check, no nonce to check, and no need to check if EOA (L1 already verified it for us)
 		// Gas is free, but no refunds!
+		st.initialGas = st.msg.Gas()
+		st.gas += st.msg.Gas() // Add gas here in order to be able to execute calls.
 		return nil
 	}
 	// Only check transactions that are not fake
@@ -373,7 +375,7 @@ func (st *StateTransition) innerTransitionDb() (*ExecutionResult, error) {
 	// if deposit: skip refunds, skip tipping coinbase
 	if st.msg.Nonce() == types.DepositsNonce {
 		return &ExecutionResult{
-			UsedGas:    st.gasUsed(),
+			UsedGas:    0, // Ignore actual used gas for deposits (until full deposit gas design is done)
 			Err:        vmerr,
 			ReturnData: ret,
 		}, nil


### PR DESCRIPTION
If the `st.gas` is not set, no gas is provided to the EVM resulting
in an immediate Out Of Gas error. While deposits do not affect the
gas pool, the EVM still expects to do gas metering.

Initial gas is still done for metering, but should be not used
for deposit transactions.


