### PR TITLE
rpc: Add WithAuth and Auth Provider 

### DIFF
--- a/rpc/auth.go
+++ b/rpc/auth.go
@@ -1,0 +1,41 @@
+package rpc
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+)
+
+// HeaderAuthProvider is an interface for adding JWT Bearer Tokens to HTTP/WS (on the initial upgrade)
+// requests to authenticated APIs.
+// See https://github.com/ethereum/execution-apis/blob/main/src/engine/authentication.md for details
+// about the authentication scheme.
+type HeaderAuthProvider interface {
+	// AddAuthHeader adds an up to date Authorization Bearer token field to the header
+	AddAuthHeader(header *http.Header) error
+}
+
+type JWTAuthProvider struct {
+	secret []byte
+}
+
+// NewJWTAuthProvider creates a new JWT Auth Provider.
+// The secret should not be empty.
+func NewJWTAuthProvider(jwtsecret []byte) *JWTAuthProvider {
+	return &JWTAuthProvider{secret: jwtsecret}
+}
+
+// AddAuthHeader adds a JWT Authorization token to the header
+func (p *JWTAuthProvider) AddAuthHeader(header *http.Header) error {
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"iat": time.Now().Unix(),
+	})
+	s, err := token.SignedString(p.secret)
+	if err != nil {
+		return fmt.Errorf("failed to create JWT token: %w", err)
+	}
+	header.Add("Authorization", "Bearer "+s)
+	return nil
+}

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -186,6 +186,25 @@ func DialContext(ctx context.Context, rawurl string) (*Client, error) {
 	}
 }
 
+func DialWithAuth(ctx context.Context, rawurl string, auth HeaderAuthProvider) (*Client, error) {
+	u, err := url.Parse(rawurl)
+	if err != nil {
+		return nil, err
+	}
+	switch u.Scheme {
+	case "http", "https":
+		return DialHTTPWithAuth(rawurl, auth)
+	case "ws", "wss":
+		return DialWebsocketWithAuth(ctx, rawurl, "", auth)
+	case "stdio":
+		return DialStdIO(ctx)
+	case "":
+		return DialIPC(ctx, rawurl)
+	default:
+		return nil, fmt.Errorf("no known transport for URL scheme %q", u.Scheme)
+	}
+}
+
 // ClientFromContext retrieves the client from the context, if any. This can be used to perform
 // 'reverse calls' in a handler method.
 func ClientFromContext(ctx context.Context) (*Client, bool) {

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -46,6 +46,7 @@ type httpConn struct {
 	closeCh   chan interface{}
 	mu        sync.Mutex // protects headers
 	headers   http.Header
+	auth      HeaderAuthProvider // authorization provider. Must be called on each request as token claims the current time
 }
 
 // httpConn implements ServerCodec, but it is treated specially by Client
@@ -138,6 +139,30 @@ func DialHTTP(endpoint string) (*Client, error) {
 	return DialHTTPWithClient(endpoint, new(http.Client))
 }
 
+// DialHTTPWithAuth creates a new authenticated RPC client that connects to an RPC server over HTTP.
+func DialHTTPWithAuth(endpoint string, auth HeaderAuthProvider) (*Client, error) {
+	// Sanity check URL so we don't end up with a client that will fail every request.
+	_, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, err
+	}
+	client := new(http.Client)
+	initctx := context.Background()
+	headers := make(http.Header, 2)
+	headers.Set("accept", contentType)
+	headers.Set("content-type", contentType)
+	return newClient(initctx, func(context.Context) (ServerCodec, error) {
+		hc := &httpConn{
+			client:  client,
+			headers: headers,
+			url:     endpoint,
+			closeCh: make(chan interface{}),
+			auth:    auth,
+		}
+		return hc, nil
+	})
+}
+
 func (c *Client) sendHTTP(ctx context.Context, op *requestOp, msg interface{}) error {
 	hc := c.writeConn.(*httpConn)
 	respBody, err := hc.doRequest(ctx, msg)
@@ -187,6 +212,12 @@ func (hc *httpConn) doRequest(ctx context.Context, msg interface{}) (io.ReadClos
 	hc.mu.Lock()
 	req.Header = hc.headers.Clone()
 	hc.mu.Unlock()
+	if hc.auth != nil {
+		err = hc.auth.AddAuthHeader(&req.Header)
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	// do request
 	resp, err := hc.client.Do(req)

--- a/rpc/websocket.go
+++ b/rpc/websocket.go
@@ -184,7 +184,7 @@ func parseOriginURL(origin string) (string, string, string, error) {
 // DialWebsocketWithDialer creates a new RPC client that communicates with a JSON-RPC server
 // that is listening on the given endpoint using the provided dialer.
 func DialWebsocketWithDialer(ctx context.Context, endpoint, origin string, dialer websocket.Dialer) (*Client, error) {
-	endpoint, header, err := wsClientHeaders(endpoint, origin)
+	endpoint, header, err := wsClientHeaders(endpoint, origin, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -215,7 +215,36 @@ func DialWebsocket(ctx context.Context, endpoint, origin string) (*Client, error
 	return DialWebsocketWithDialer(ctx, endpoint, origin, dialer)
 }
 
-func wsClientHeaders(endpoint, origin string) (string, http.Header, error) {
+// DialWebsocketWithAuth creates a new RPC client that communicates with a JSON-RPC server
+// that is listening on the given endpoint. It uses the HeaderAuthProvider to authenticate
+// the initial HTTP connection/upgrade.
+//
+// The context is used for the initial connection establishment. It does not
+// affect subsequent interactions with the client.
+func DialWebsocketWithAuth(ctx context.Context, endpoint, origin string, auth HeaderAuthProvider) (*Client, error) {
+	endpoint, header, err := wsClientHeaders(endpoint, origin, auth)
+	if err != nil {
+		return nil, err
+	}
+	dialer := websocket.Dialer{
+		ReadBufferSize:  wsReadBuffer,
+		WriteBufferSize: wsWriteBuffer,
+		WriteBufferPool: wsBufferPool,
+	}
+	return newClient(ctx, func(ctx context.Context) (ServerCodec, error) {
+		conn, resp, err := dialer.DialContext(ctx, endpoint, header)
+		if err != nil {
+			hErr := wsHandshakeError{err: err}
+			if resp != nil {
+				hErr.status = resp.Status
+			}
+			return nil, hErr
+		}
+		return newWebsocketCodec(conn, endpoint, header), nil
+	})
+}
+
+func wsClientHeaders(endpoint, origin string, authProvider HeaderAuthProvider) (string, http.Header, error) {
 	endpointURL, err := url.Parse(endpoint)
 	if err != nil {
 		return endpoint, nil, err
@@ -223,6 +252,13 @@ func wsClientHeaders(endpoint, origin string) (string, http.Header, error) {
 	header := make(http.Header)
 	if origin != "" {
 		header.Add("origin", origin)
+	}
+	// Add JWT Authorization Header if provided
+	if authProvider != nil {
+		err = authProvider.AddAuthHeader(&header)
+		if err != nil {
+			return endpoint, nil, err
+		}
 	}
 	if endpointURL.User != nil {
 		b64auth := base64.StdEncoding.EncodeToString([]byte(endpointURL.User.String()))

--- a/rpc/websocket_test.go
+++ b/rpc/websocket_test.go
@@ -36,7 +36,7 @@ import (
 func TestWebsocketClientHeaders(t *testing.T) {
 	t.Parallel()
 
-	endpoint, header, err := wsClientHeaders("wss://testuser:test-PASS_01@example.com:1234", "https://example.com")
+	endpoint, header, err := wsClientHeaders("wss://testuser:test-PASS_01@example.com:1234", "https://example.com", nil)
 	if err != nil {
 		t.Fatalf("wsGetConfig failed: %s", err)
 	}


### PR DESCRIPTION
**Description**
This adds the HeaderAuthProvider interface which creates a timely
JWT Bearer token. The token is then added to the headers for the
request. This is working with both HTTP Clients and Websocket
Clients.

**Testing**
I manually tested that a modified consolecmd was able to connect over WS and HTTP
to authenticated RPC servers. I tested with and without valid keys to confirm that it
would work only if a valid key was provided.

Build, lint, and unit tests pass locally. CI Is broken here.

**Metadata**
- Fixes  ENG-2205
