### PR TITLE
p2p: smaller max tx size

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -50,7 +50,7 @@ const (
 	// non-trivial consequences: larger transactions are significantly harder and
 	// more expensive to propagate; larger transactions also take more resources
 	// to validate whether they fit into the pool or not.
-	txMaxSize = 4 * txSlotSize // 128KB
+	txMaxSize = 126000
 )
 
 var (


### PR DESCRIPTION
**Description**

All L2 transactions must be able to be included
in an L1 block as part of a L1 transaction.
It would be very inconvenient if users submitted
transactions to L2 that resulted in the L1 transaction
not being able to be gossiped around the L1 p2p network.
This commit restricts the max size of a L2 transaction
being accepted into the mempool such that it can be
included in an L1 transaction.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Additional context**
https://github.com/ethereum-optimism/optimistic-specs/pull/397

