### PR TITLE
Don't panic on deposit transaction signature values

### DIFF
--- a/core/types/deposit_tx.go
+++ b/core/types/deposit_tx.go
@@ -24,8 +24,6 @@ import (
 
 const DepositTxType = 0x7E
 
-var zeroBig = new(big.Int)
-
 type DepositTx struct {
 	// SourceHash uniquely identifies the source of the deposit
 	SourceHash common.Hash
@@ -81,7 +79,7 @@ func (tx *DepositTx) nonce() uint64          { return DepositsNonce }
 func (tx *DepositTx) to() *common.Address    { return tx.To }
 
 func (tx *DepositTx) rawSignatureValues() (v, r, s *big.Int) {
-	return zeroBig, zeroBig, zeroBig
+	return common.Big0, common.Big0, common.Big0
 }
 
 func (tx *DepositTx) setSignatureValues(chainID, v, r, s *big.Int) {

--- a/core/types/deposit_tx.go
+++ b/core/types/deposit_tx.go
@@ -66,7 +66,7 @@ const DepositsNonce uint64 = 0xffff_ffff_ffff_fffd
 
 // accessors for innerTx.
 func (tx *DepositTx) txType() byte           { return DepositTxType }
-func (tx *DepositTx) chainID() *big.Int      { panic("deposits are not signed and do not have a chain-ID") }
+func (tx *DepositTx) chainID() *big.Int      { return common.Big0 }
 func (tx *DepositTx) protected() bool        { return true }
 func (tx *DepositTx) accessList() AccessList { return nil }
 func (tx *DepositTx) data() []byte           { return tx.Data }

--- a/core/types/deposit_tx.go
+++ b/core/types/deposit_tx.go
@@ -24,6 +24,8 @@ import (
 
 const DepositTxType = 0x7E
 
+var zeroBig = new(big.Int)
+
 type DepositTx struct {
 	// SourceHash uniquely identifies the source of the deposit
 	SourceHash common.Hash
@@ -79,9 +81,9 @@ func (tx *DepositTx) nonce() uint64          { return DepositsNonce }
 func (tx *DepositTx) to() *common.Address    { return tx.To }
 
 func (tx *DepositTx) rawSignatureValues() (v, r, s *big.Int) {
-	panic("deposit tx does not have a signature")
+	return zeroBig, zeroBig, zeroBig
 }
 
 func (tx *DepositTx) setSignatureValues(chainID, v, r, s *big.Int) {
-	panic("deposit tx does not have a signature")
+	// this is a noop for deposit transactions
 }


### PR DESCRIPTION
Instead of panicking on `rawSignatureValues`, return zero for V, R, and S. Panicking in those methods breaks users of the Go client like Hive, since transaction serialization calls `rawSignatureValues` under the hood.
