### PR TITLE
core: Add version to DepositTx

### DIFF
--- a/core/types/deposit_tx.go
+++ b/core/types/deposit_tx.go
@@ -22,6 +22,10 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
+const (
+	DepositTxVersionZeroType = iota
+)
+
 const DepositTxType = 0x7E
 
 type DepositTx struct {


### PR DESCRIPTION
**Description**

This adds a second byte after the EIP-2718 Type byte to deposit
transactions that versions the deposit. It is placed prior to the start
of the RLP to make it easier to extend the transaction in the future. We
choose to version inside the EIP-2718 envelope to limit the number of
EIP-2718 prefixes we take for deposit transactions.

**Metadata**
- Fixes ENG-2221
