### PR TITLE
ethapi: Remove unnecessary cast

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1251,7 +1251,7 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 			To:         tx.To(),
 			Value:      (*hexutil.Big)(tx.Value()),
 			Mint:       (*hexutil.Big)(tx.Mint()),
-			SourceHash: (*common.Hash)(&srcHash),
+			SourceHash: &srcHash,
 		}
 		if blockHash != (common.Hash{}) {
 			result.BlockHash = &blockHash


### PR DESCRIPTION
**Description**
Removes a cast that was causing the linter to fail.


