### PR TITLE
Rebased geth + cherry-pick Engine Auth utils

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,13 @@ workflows:
               only:
                 - optimism-prototype
           image-name: reference-optimistic-geth
-          image-tag: develop
+          image-tag: latest
           dockerfile: Dockerfile
-          name: Build reference-optimistic-geth
+          name: Build reference-optimistic-geth develop
+      - build-dockerfile:
+          context:
+            - optimism
+          image-name: reference-optimistic-geth
+          image-tag: $CIRCLE_SHA1
+          dockerfile: Dockerfile
+          name: Build reference-optimistic-geth per-commit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,31 @@
 version: 2.1
 
-
 jobs:
+  build-geth:
+    docker:
+      - image: cimg/go:1.18
+    resource_class: medium
+    steps:
+      - checkout
+      - run:
+          command: go run build/ci.go install
+  unit-test:
+    resource_class: medium
+    docker:
+      - image: cimg/go:1.18
+    steps:
+      - checkout
+      - run:
+          command: go run build/ci.go test
+  lint-geth:
+    resource_class: medium
+    docker:
+      - image: cimg/go:1.18
+    steps:
+      - checkout
+      - run:
+          command: go run build/ci.go lint
+
   build-dockerfile:
     docker:
       - image: cimg/base:2022.04
@@ -33,6 +57,12 @@ jobs:
 workflows:
   main:
     jobs:
+      - build-geth:
+          name: Build geth
+      - unit-test:
+          name: Run unit tests for geth
+      - lint-geth:
+          name: Run linter over geth
       - build-dockerfile:
           context:
             - optimism

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,46 @@
+version: 2.1
+
+
+jobs:
+  build-dockerfile:
+    docker:
+      - image: cimg/base:2022.04
+    parameters:
+      image-name:
+        description: Image name
+        type: string
+      image-tag:
+        description: Image tag
+        type: string
+      target:
+        description: Dockerfile target
+        type: string
+        default: ""
+      dockerfile:
+        description: Dockerfile to use
+        type: string
+    steps:
+      - checkout
+      - setup_remote_docker:
+          version: 20.10.12
+      - run:
+          name: Build
+          command: |
+            echo "$DOCKER_PASS" | docker login -u "$DOCKER_USERNAME" --password-stdin
+            docker build -t "ethereumoptimism/<<parameters.image-name>>:<<parameters.image-tag>>" -f <<parameters.dockerfile>> <<#parameters.target>>--target <<parameters.target>><</parameters.target>> .
+            docker push "ethereumoptimism/<<parameters.image-name>>:<<parameters.image-tag>>"
+
+workflows:
+  main:
+    jobs:
+      - build-dockerfile:
+          context:
+            - optimism
+          filters:
+            branches:
+              only:
+                - optimism-prototype
+          image-name: reference-optimistic-geth
+          image-tag: develop
+          dockerfile: Dockerfile
+          name: Build reference-optimistic-geth

--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -812,6 +812,7 @@ func (m callMsg) Gas() uint64                  { return m.CallMsg.Gas }
 func (m callMsg) Value() *big.Int              { return m.CallMsg.Value }
 func (m callMsg) Data() []byte                 { return m.CallMsg.Data }
 func (m callMsg) AccessList() types.AccessList { return m.CallMsg.AccessList }
+func (m callMsg) Mint() *big.Int               { return nil }
 
 // filterBackend implements filters.Backend to support filtering for logs without
 // taking bloom-bits acceleration structures into account.

--- a/core/beacon/gen_blockparams.go
+++ b/core/beacon/gen_blockparams.go
@@ -19,6 +19,7 @@ func (p PayloadAttributesV1) MarshalJSON() ([]byte, error) {
 		Random                common.Hash     `json:"prevRandao"        gencodec:"required"`
 		SuggestedFeeRecipient common.Address  `json:"suggestedFeeRecipient"  gencodec:"required"`
 		Transactions          []hexutil.Bytes `json:"transactions,omitempty"  gencodec:"optional"`
+		NoTxPool              bool            `json:"noTxPool,omitempty" gencodec:"optional"`
 	}
 	var enc PayloadAttributesV1
 	enc.Timestamp = hexutil.Uint64(p.Timestamp)
@@ -30,6 +31,7 @@ func (p PayloadAttributesV1) MarshalJSON() ([]byte, error) {
 			enc.Transactions[k] = v
 		}
 	}
+	enc.NoTxPool = p.NoTxPool
 	return json.Marshal(&enc)
 }
 
@@ -40,6 +42,7 @@ func (p *PayloadAttributesV1) UnmarshalJSON(input []byte) error {
 		Random                *common.Hash    `json:"prevRandao"        gencodec:"required"`
 		SuggestedFeeRecipient *common.Address `json:"suggestedFeeRecipient"  gencodec:"required"`
 		Transactions          []hexutil.Bytes `json:"transactions,omitempty"  gencodec:"optional"`
+		NoTxPool              *bool           `json:"noTxPool,omitempty" gencodec:"optional"`
 	}
 	var dec PayloadAttributesV1
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -62,6 +65,9 @@ func (p *PayloadAttributesV1) UnmarshalJSON(input []byte) error {
 		for k, v := range dec.Transactions {
 			p.Transactions[k] = v
 		}
+	}
+	if dec.NoTxPool != nil {
+		p.NoTxPool = *dec.NoTxPool
 	}
 	return nil
 }

--- a/core/beacon/gen_blockparams.go
+++ b/core/beacon/gen_blockparams.go
@@ -15,14 +15,21 @@ var _ = (*payloadAttributesMarshaling)(nil)
 // MarshalJSON marshals as JSON.
 func (p PayloadAttributesV1) MarshalJSON() ([]byte, error) {
 	type PayloadAttributesV1 struct {
-		Timestamp             hexutil.Uint64 `json:"timestamp"     gencodec:"required"`
-		Random                common.Hash    `json:"prevRandao"        gencodec:"required"`
-		SuggestedFeeRecipient common.Address `json:"suggestedFeeRecipient"  gencodec:"required"`
+		Timestamp             hexutil.Uint64  `json:"timestamp"     gencodec:"required"`
+		Random                common.Hash     `json:"prevRandao"        gencodec:"required"`
+		SuggestedFeeRecipient common.Address  `json:"suggestedFeeRecipient"  gencodec:"required"`
+		Transactions          []hexutil.Bytes `json:"transactions,omitempty"  gencodec:"optional"`
 	}
 	var enc PayloadAttributesV1
 	enc.Timestamp = hexutil.Uint64(p.Timestamp)
 	enc.Random = p.Random
 	enc.SuggestedFeeRecipient = p.SuggestedFeeRecipient
+	if p.Transactions != nil {
+		enc.Transactions = make([]hexutil.Bytes, len(p.Transactions))
+		for k, v := range p.Transactions {
+			enc.Transactions[k] = v
+		}
+	}
 	return json.Marshal(&enc)
 }
 
@@ -32,6 +39,7 @@ func (p *PayloadAttributesV1) UnmarshalJSON(input []byte) error {
 		Timestamp             *hexutil.Uint64 `json:"timestamp"     gencodec:"required"`
 		Random                *common.Hash    `json:"prevRandao"        gencodec:"required"`
 		SuggestedFeeRecipient *common.Address `json:"suggestedFeeRecipient"  gencodec:"required"`
+		Transactions          []hexutil.Bytes `json:"transactions,omitempty"  gencodec:"optional"`
 	}
 	var dec PayloadAttributesV1
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -49,5 +57,11 @@ func (p *PayloadAttributesV1) UnmarshalJSON(input []byte) error {
 		return errors.New("missing required field 'suggestedFeeRecipient' for PayloadAttributesV1")
 	}
 	p.SuggestedFeeRecipient = *dec.SuggestedFeeRecipient
+	if dec.Transactions != nil {
+		p.Transactions = make([][]byte, len(dec.Transactions))
+		for k, v := range dec.Transactions {
+			p.Transactions[k] = v
+		}
+	}
 	return nil
 }

--- a/core/beacon/types.go
+++ b/core/beacon/types.go
@@ -33,11 +33,16 @@ type PayloadAttributesV1 struct {
 	Timestamp             uint64         `json:"timestamp"     gencodec:"required"`
 	Random                common.Hash    `json:"prevRandao"        gencodec:"required"`
 	SuggestedFeeRecipient common.Address `json:"suggestedFeeRecipient"  gencodec:"required"`
+
+	// Transactions is a field for rollups: if non-empty, the transactions list is used instead
+	// of any transactions from the engine like the tx-pool.
+	Transactions [][]byte `json:"transactions,omitempty"  gencodec:"optional"`
 }
 
 // JSON type overrides for PayloadAttributesV1.
 type payloadAttributesMarshaling struct {
-	Timestamp hexutil.Uint64
+	Timestamp    hexutil.Uint64
+	Transactions []hexutil.Bytes
 }
 
 //go:generate go run github.com/fjl/gencodec -type ExecutableDataV1 -field-override executableDataMarshaling -out gen_ed.go

--- a/core/beacon/types.go
+++ b/core/beacon/types.go
@@ -34,9 +34,11 @@ type PayloadAttributesV1 struct {
 	Random                common.Hash    `json:"prevRandao"        gencodec:"required"`
 	SuggestedFeeRecipient common.Address `json:"suggestedFeeRecipient"  gencodec:"required"`
 
-	// Transactions is a field for rollups: if non-empty, the transactions list is used instead
-	// of any transactions from the engine like the tx-pool.
+	// Transactions is a field for rollups: the transactions list is forced into the block
 	Transactions [][]byte `json:"transactions,omitempty"  gencodec:"optional"`
+	// NoTxPool is a field for rollups: if true, the no transactions are taken out of the tx-pool,
+	// only transactions from the above Transactions list will be included.
+	NoTxPool bool `json:"noTxPool,omitempty" gencodec:"optional"`
 }
 
 // JSON type overrides for PayloadAttributesV1.

--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -63,13 +63,12 @@ func (v *BlockValidator) ValidateBody(block *types.Block) error {
 		return fmt.Errorf("uncle root hash mismatch: have %x, want %x", hash, header.UncleHash)
 	}
 	// deposits included their positional information for tx-hashing purposes.
-	// height := block.NumberU64()
+	height := block.NumberU64()
 	for i, tx := range block.Transactions() {
 		if tx.Type() == types.DepositTxType {
-			// TODO: Deposit Tx includes the height of the L1 block, not the L2 block
-			// if tx.BlockHeight() != height {
-			// 	return fmt.Errorf("deposit included in block with wrong block height: %d, expected %d", tx.BlockHeight(), height)
-			// }
+			if tx.BlockHeight() != height {
+				return fmt.Errorf("deposit included in block with wrong block height: %d, expected %d", tx.BlockHeight(), height)
+			}
 			if tx.TransactionIndex() != uint64(i) {
 				return fmt.Errorf("deposit included in block at wrong index: %d, expected %d", tx.TransactionIndex(), i)
 			}

--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -62,18 +62,6 @@ func (v *BlockValidator) ValidateBody(block *types.Block) error {
 	if hash := types.CalcUncleHash(block.Uncles()); hash != header.UncleHash {
 		return fmt.Errorf("uncle root hash mismatch: have %x, want %x", hash, header.UncleHash)
 	}
-	// deposits included their positional information for tx-hashing purposes.
-	height := block.NumberU64()
-	for i, tx := range block.Transactions() {
-		if tx.Type() == types.DepositTxType {
-			if tx.BlockHeight() != height {
-				return fmt.Errorf("deposit included in block with wrong block height: %d, expected %d", tx.BlockHeight(), height)
-			}
-			if tx.TransactionIndex() != uint64(i) {
-				return fmt.Errorf("deposit included in block at wrong index: %d, expected %d", tx.TransactionIndex(), i)
-			}
-		}
-	}
 	if hash := types.DeriveSha(block.Transactions(), trie.NewStackTrie(nil)); hash != header.TxHash {
 		return fmt.Errorf("transaction root hash mismatch: have %x, want %x", hash, header.TxHash)
 	}

--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -63,12 +63,13 @@ func (v *BlockValidator) ValidateBody(block *types.Block) error {
 		return fmt.Errorf("uncle root hash mismatch: have %x, want %x", hash, header.UncleHash)
 	}
 	// deposits included their positional information for tx-hashing purposes.
-	height := block.NumberU64()
+	// height := block.NumberU64()
 	for i, tx := range block.Transactions() {
 		if tx.Type() == types.DepositTxType {
-			if tx.BlockHeight() != height {
-				return fmt.Errorf("deposit included in block with wrong block height: %d, expected %d", tx.BlockHeight(), height)
-			}
+			// TODO: Deposit Tx includes the height of the L1 block, not the L2 block
+			// if tx.BlockHeight() != height {
+			// 	return fmt.Errorf("deposit included in block with wrong block height: %d, expected %d", tx.BlockHeight(), height)
+			// }
 			if tx.TransactionIndex() != uint64(i) {
 				return fmt.Errorf("deposit included in block at wrong index: %d, expected %d", tx.TransactionIndex(), i)
 			}

--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -62,6 +62,18 @@ func (v *BlockValidator) ValidateBody(block *types.Block) error {
 	if hash := types.CalcUncleHash(block.Uncles()); hash != header.UncleHash {
 		return fmt.Errorf("uncle root hash mismatch: have %x, want %x", hash, header.UncleHash)
 	}
+	// deposits included their positional information for tx-hashing purposes.
+	height := block.NumberU64()
+	for i, tx := range block.Transactions() {
+		if tx.Type() == types.DepositTxType {
+			if tx.BlockHeight() != height {
+				return fmt.Errorf("deposit included in block with wrong block height: %d, expected %d", tx.BlockHeight(), height)
+			}
+			if tx.TransactionIndex() != uint64(i) {
+				return fmt.Errorf("deposit included in block at wrong index: %d, expected %d", tx.TransactionIndex(), i)
+			}
+		}
+	}
 	if hash := types.DeriveSha(block.Transactions(), trie.NewStackTrie(nil)); hash != header.TxHash {
 		return fmt.Errorf("transaction root hash mismatch: have %x, want %x", hash, header.TxHash)
 	}

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -57,6 +57,7 @@ type StateTransition struct {
 	gasTipCap  *big.Int
 	initialGas uint64
 	value      *big.Int
+	mint       *big.Int
 	data       []byte
 	state      vm.StateDB
 	evm        *vm.EVM
@@ -72,6 +73,9 @@ type Message interface {
 	GasTipCap() *big.Int
 	Gas() uint64
 	Value() *big.Int
+
+	// Mint is nil if there is no minting
+	Mint() *big.Int
 
 	Nonce() uint64
 	IsFake() bool
@@ -165,6 +169,7 @@ func NewStateTransition(evm *vm.EVM, msg Message, gp *GasPool) *StateTransition 
 		gasFeeCap: msg.GasFeeCap(),
 		gasTipCap: msg.GasTipCap(),
 		value:     msg.Value(),
+		mint:      msg.Mint(),
 		data:      msg.Data(),
 		state:     evm.StateDB,
 	}
@@ -212,6 +217,11 @@ func (st *StateTransition) buyGas() error {
 }
 
 func (st *StateTransition) preCheck() error {
+	if st.msg.Nonce() == types.DepositsNonce {
+		// No fee fields to check, no nonce to check, and no need to check if EOA (L1 already verified it for us)
+		// Gas is free, but no refunds!
+		return nil
+	}
 	// Only check transactions that are not fake
 	if !st.msg.IsFake() {
 		// Make sure this transaction's nonce is correct.
@@ -273,6 +283,14 @@ func (st *StateTransition) preCheck() error {
 // However if any consensus issue encountered, return the error directly with
 // nil evm execution result.
 func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
+	if st.mint != nil {
+		// The deposit mints value into the account before execution
+		// This is NOT rolled back if EVM execution fails.
+		// If the EVM execution fails (e.g. out of gas) then the deposited ETH remains in the L2,
+		// in the deposit From address.
+		st.state.AddBalance(st.msg.From(), st.mint)
+	}
+
 	// First check this message satisfies all consensus rules before
 	// applying the message. The rules include these clauses
 	//
@@ -302,15 +320,17 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 		contractCreation = msg.To() == nil
 	)
 
-	// Check clauses 4-5, subtract intrinsic gas if everything is correct
-	gas, err := IntrinsicGas(st.data, st.msg.AccessList(), contractCreation, rules.IsHomestead, rules.IsIstanbul)
-	if err != nil {
-		return nil, err
+	if st.msg.Nonce() != types.DepositsNonce {
+		// Check clauses 4-5, subtract intrinsic gas if everything is correct
+		gas, err := IntrinsicGas(st.data, st.msg.AccessList(), contractCreation, rules.IsHomestead, rules.IsIstanbul)
+		if err != nil {
+			return nil, err
+		}
+		if st.gas < gas {
+			return nil, fmt.Errorf("%w: have %d, want %d", ErrIntrinsicGas, st.gas, gas)
+		}
+		st.gas -= gas
 	}
-	if st.gas < gas {
-		return nil, fmt.Errorf("%w: have %d, want %d", ErrIntrinsicGas, st.gas, gas)
-	}
-	st.gas -= gas
 
 	// Check clause 6
 	if msg.Value().Sign() > 0 && !st.evm.Context.CanTransfer(st.state, msg.From(), msg.Value()) {
@@ -333,6 +353,14 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 		ret, st.gas, vmerr = st.evm.Call(sender, st.to(), st.data, st.gas, st.value)
 	}
 
+	// if deposit: skip refunds, skip tipping coinbase
+	if st.msg.Nonce() == types.DepositsNonce {
+		return &ExecutionResult{
+			UsedGas:    st.gasUsed(),
+			Err:        vmerr,
+			ReturnData: ret,
+		}, nil
+	}
 	if !rules.IsLondon {
 		// Before EIP-3529: refunds were capped to gasUsed / 2
 		st.refundGas(params.RefundQuotient)

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -220,6 +220,8 @@ func (st *StateTransition) preCheck() error {
 	if st.msg.Nonce() == types.DepositsNonce {
 		// No fee fields to check, no nonce to check, and no need to check if EOA (L1 already verified it for us)
 		// Gas is free, but no refunds!
+		st.initialGas = st.msg.Gas()
+		st.gas += st.msg.Gas() // Add gas here in order to be able to execute calls.
 		return nil
 	}
 	// Only check transactions that are not fake
@@ -373,7 +375,7 @@ func (st *StateTransition) innerTransitionDb() (*ExecutionResult, error) {
 	// if deposit: skip refunds, skip tipping coinbase
 	if st.msg.Nonce() == types.DepositsNonce {
 		return &ExecutionResult{
-			UsedGas:    st.gasUsed(),
+			UsedGas:    0, // Ignore actual used gas for deposits (until full deposit gas design is done)
 			Err:        vmerr,
 			ReturnData: ret,
 		}, nil

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -1283,6 +1283,16 @@ func (pool *TxPool) reset(oldHead, newHead *types.Header) {
 						return
 					}
 				}
+				// Do not insert deposit txs back into the pool
+				// (validateTx would still catch it if not filtered, but no need to re-inject in the first place).
+				j := 0
+				for _, tx := range discarded {
+					if tx.Type() != types.DepositTxType {
+						discarded[j] = tx
+						j++
+					}
+				}
+				discarded = discarded[:j]
 				reinject = types.TxDifference(discarded, included)
 			}
 		}

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -584,6 +584,12 @@ func (pool *TxPool) local() map[common.Address]types.Transactions {
 // validateTx checks whether a transaction is valid according to the consensus
 // rules and adheres to some heuristic limits of the local node (price and size).
 func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
+	// No unauthenticated deposits allowed in the transaction pool.
+	// This is for spam protection, not consensus,
+	// as the external engine-API user authenticates deposits.
+	if tx.Type() == types.DepositTxType {
+		return ErrTxTypeNotSupported
+	}
 	// Accept only legacy transactions until EIP-2718/2930 activates.
 	if !pool.eip2718 && tx.Type() != types.LegacyTxType {
 		return ErrTxTypeNotSupported

--- a/core/types/deposit_tx.go
+++ b/core/types/deposit_tx.go
@@ -66,7 +66,7 @@ const DepositsNonce uint64 = 0xffff_ffff_ffff_fffd
 
 // accessors for innerTx.
 func (tx *DepositTx) txType() byte           { return DepositTxType }
-func (tx *DepositTx) chainID() *big.Int      { panic("deposits are not signed and do not have a chain-ID") }
+func (tx *DepositTx) chainID() *big.Int      { return common.Big0 }
 func (tx *DepositTx) protected() bool        { return true }
 func (tx *DepositTx) accessList() AccessList { return nil }
 func (tx *DepositTx) data() []byte           { return tx.Data }
@@ -79,9 +79,9 @@ func (tx *DepositTx) nonce() uint64          { return DepositsNonce }
 func (tx *DepositTx) to() *common.Address    { return tx.To }
 
 func (tx *DepositTx) rawSignatureValues() (v, r, s *big.Int) {
-	panic("deposit tx does not have a signature")
+	return common.Big0, common.Big0, common.Big0
 }
 
 func (tx *DepositTx) setSignatureValues(chainID, v, r, s *big.Int) {
-	panic("deposit tx does not have a signature")
+	// this is a noop for deposit transactions
 }

--- a/core/types/deposit_tx.go
+++ b/core/types/deposit_tx.go
@@ -25,10 +25,8 @@ import (
 const DepositTxType = 0x7E
 
 type DepositTx struct {
-	// BlockHeight avoids tx-hash collisions between deposits on the same chain
-	BlockHeight uint64
-	// TransactionIndex avoids tx-hash collisions between deposits in the same block
-	TransactionIndex uint64
+	// SourceHash uniquely identifies the source of the deposit
+	SourceHash common.Hash
 	// From is exposed through the types.Signer, not through TxData
 	From common.Address
 	// nil means contract creation
@@ -45,14 +43,13 @@ type DepositTx struct {
 // copy creates a deep copy of the transaction data and initializes all fields.
 func (tx *DepositTx) copy() TxData {
 	cpy := &DepositTx{
-		BlockHeight:      tx.BlockHeight,
-		TransactionIndex: tx.TransactionIndex,
-		From:             tx.From,
-		To:               copyAddressPtr(tx.To),
-		Mint:             nil,
-		Value:            new(big.Int),
-		Gas:              tx.Gas,
-		Data:             common.CopyBytes(tx.Data),
+		SourceHash: tx.SourceHash,
+		From:       tx.From,
+		To:         copyAddressPtr(tx.To),
+		Mint:       nil,
+		Value:      new(big.Int),
+		Gas:        tx.Gas,
+		Data:       common.CopyBytes(tx.Data),
 	}
 	if tx.Mint != nil {
 		cpy.Mint = new(big.Int).Set(tx.Mint)

--- a/core/types/deposit_tx.go
+++ b/core/types/deposit_tx.go
@@ -1,0 +1,90 @@
+// Copyright 2021 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package types
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+const DepositTxType = 0x7E
+
+type DepositTx struct {
+	// BlockHeight avoids tx-hash collisions between deposits on the same chain
+	BlockHeight uint64
+	// TransactionIndex avoids tx-hash collisions between deposits in the same block
+	TransactionIndex uint64
+	// From is exposed through the types.Signer, not through TxData
+	From common.Address
+	// nil means contract creation
+	To *common.Address `rlp:"nil"`
+	// Mint is minted on L2, locked on L1, nil if no minting.
+	Mint *big.Int `rlp:"nil"`
+	// Value is transferred from L2 balance, executed after Mint (if any)
+	Value *big.Int
+	// gas limit
+	Gas  uint64
+	Data []byte
+}
+
+// copy creates a deep copy of the transaction data and initializes all fields.
+func (tx *DepositTx) copy() TxData {
+	cpy := &DepositTx{
+		BlockHeight:      tx.BlockHeight,
+		TransactionIndex: tx.TransactionIndex,
+		From:             tx.From,
+		To:               copyAddressPtr(tx.To),
+		Mint:             nil,
+		Value:            new(big.Int),
+		Gas:              tx.Gas,
+		Data:             common.CopyBytes(tx.Data),
+	}
+	if tx.Mint != nil {
+		cpy.Mint = new(big.Int).Set(tx.Mint)
+	}
+	if tx.Value != nil {
+		cpy.Value.Set(tx.Value)
+	}
+	return cpy
+}
+
+// DepositsNonce identifies a deposit, since go-ethereum abstracts all transaction types to a core.Message.
+// Deposits do not set a nonce, deposits are included by the system and cannot be repeated or included elsewhere.
+const DepositsNonce uint64 = 0xffff_ffff_ffff_ffff
+
+// accessors for innerTx.
+func (tx *DepositTx) txType() byte           { return DepositTxType }
+func (tx *DepositTx) chainID() *big.Int      { panic("deposits are not signed and do not have a chain-ID") }
+func (tx *DepositTx) protected() bool        { return true }
+func (tx *DepositTx) accessList() AccessList { return nil }
+func (tx *DepositTx) data() []byte           { return tx.Data }
+func (tx *DepositTx) gas() uint64            { return tx.Gas }
+func (tx *DepositTx) gasFeeCap() *big.Int    { return new(big.Int) }
+func (tx *DepositTx) gasTipCap() *big.Int    { return new(big.Int) }
+func (tx *DepositTx) gasPrice() *big.Int     { return new(big.Int) }
+func (tx *DepositTx) value() *big.Int        { return tx.Value }
+func (tx *DepositTx) nonce() uint64          { return DepositsNonce }
+func (tx *DepositTx) to() *common.Address    { return tx.To }
+
+func (tx *DepositTx) rawSignatureValues() (v, r, s *big.Int) {
+	panic("deposit tx does not have a signature")
+}
+
+func (tx *DepositTx) setSignatureValues(chainID, v, r, s *big.Int) {
+	panic("deposit tx does not have a signature")
+}

--- a/core/types/deposit_tx.go
+++ b/core/types/deposit_tx.go
@@ -22,6 +22,10 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
+const (
+	DepositTxVersionZeroType = iota
+)
+
 const DepositTxType = 0x7E
 
 type DepositTx struct {

--- a/core/types/deposit_tx.go
+++ b/core/types/deposit_tx.go
@@ -65,7 +65,7 @@ func (tx *DepositTx) copy() TxData {
 
 // DepositsNonce identifies a deposit, since go-ethereum abstracts all transaction types to a core.Message.
 // Deposits do not set a nonce, deposits are included by the system and cannot be repeated or included elsewhere.
-const DepositsNonce uint64 = 0xffff_ffff_ffff_ffff
+const DepositsNonce uint64 = 0xffff_ffff_ffff_fffd
 
 // accessors for innerTx.
 func (tx *DepositTx) txType() byte           { return DepositTxType }

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -214,7 +214,7 @@ func (r *Receipt) decodeTyped(b []byte) error {
 		return errShortTypedReceipt
 	}
 	switch b[0] {
-	case DynamicFeeTxType, AccessListTxType:
+	case DynamicFeeTxType, AccessListTxType, DepositTxType:
 		var data receiptRLP
 		err := rlp.DecodeBytes(b[1:], &data)
 		if err != nil {
@@ -386,6 +386,9 @@ func (rs Receipts) EncodeIndex(i int, w *bytes.Buffer) {
 		rlp.Encode(w, data)
 	case DynamicFeeTxType:
 		w.WriteByte(DynamicFeeTxType)
+		rlp.Encode(w, data)
+	case DepositTxType:
+		w.WriteByte(DepositTxType)
 		rlp.Encode(w, data)
 	default:
 		// For unsupported types, write nothing. Since this is for

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -289,22 +289,14 @@ func (tx *Transaction) To() *common.Address {
 	return copyAddressPtr(tx.inner.to())
 }
 
-// BlockHeight returns the L2 block height encoded in the deposit tx.
-// This returns 0 if this is not a deposit tx.
-func (tx *Transaction) BlockHeight() uint64 {
+// SourceHash returns the hash that uniquely identifies the source of the deposit tx,
+// e.g. a user deposit event, or a L1 info deposit included in a specific L2 block height.
+// Non-deposit transactions return a zeroed hash.
+func (tx *Transaction) SourceHash() common.Hash {
 	if dep, ok := tx.inner.(*DepositTx); ok {
-		return dep.BlockHeight
+		return dep.SourceHash
 	}
-	return 0
-}
-
-// TransactionIndex returns the tx index encoded in the deposit tx.
-// This returns 0 if this is not a deposit tx.
-func (tx *Transaction) TransactionIndex() uint64 {
-	if dep, ok := tx.inner.(*DepositTx); ok {
-		return dep.TransactionIndex
-	}
-	return 0
+	return common.Hash{}
 }
 
 // Mint returns the ETH to mint in the deposit tx.

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -289,6 +289,8 @@ func (tx *Transaction) To() *common.Address {
 	return copyAddressPtr(tx.inner.to())
 }
 
+// BlockHeight returns the L2 block height encoded in the deposit tx.
+// This returns 0 if this is not a deposit tx.
 func (tx *Transaction) BlockHeight() uint64 {
 	if dep, ok := tx.inner.(*DepositTx); ok {
 		return dep.BlockHeight
@@ -296,6 +298,8 @@ func (tx *Transaction) BlockHeight() uint64 {
 	return 0
 }
 
+// TransactionIndex returns the tx index encoded in the deposit tx.
+// This returns 0 if this is not a deposit tx.
 func (tx *Transaction) TransactionIndex() uint64 {
 	if dep, ok := tx.inner.(*DepositTx); ok {
 		return dep.TransactionIndex
@@ -303,6 +307,8 @@ func (tx *Transaction) TransactionIndex() uint64 {
 	return 0
 }
 
+// Mint returns the ETH to mint in the deposit tx.
+// This returns nil if there is nothing to mint, or if this is not a deposit tx.
 func (tx *Transaction) Mint() *big.Int {
 	if dep, ok := tx.inner.(*DepositTx); ok {
 		return dep.Mint

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -184,6 +184,10 @@ func (tx *Transaction) decodeTyped(b []byte) (TxData, error) {
 		var inner DynamicFeeTx
 		err := rlp.DecodeBytes(b[1:], &inner)
 		return &inner, err
+	case DepositTxType:
+		var inner DepositTx
+		err := rlp.DecodeBytes(b[1:], &inner)
+		return &inner, err
 	default:
 		return nil, ErrTxTypeNotSupported
 	}
@@ -283,6 +287,27 @@ func (tx *Transaction) Nonce() uint64 { return tx.inner.nonce() }
 // For contract-creation transactions, To returns nil.
 func (tx *Transaction) To() *common.Address {
 	return copyAddressPtr(tx.inner.to())
+}
+
+func (tx *Transaction) BlockHeight() uint64 {
+	if dep, ok := tx.inner.(*DepositTx); ok {
+		return dep.BlockHeight
+	}
+	return 0
+}
+
+func (tx *Transaction) TransactionIndex() uint64 {
+	if dep, ok := tx.inner.(*DepositTx); ok {
+		return dep.TransactionIndex
+	}
+	return 0
+}
+
+func (tx *Transaction) Mint() *big.Int {
+	if dep, ok := tx.inner.(*DepositTx); ok {
+		return dep.Mint
+	}
+	return nil
 }
 
 // Cost returns gas * gasPrice + value.
@@ -590,6 +615,7 @@ type Message struct {
 	data       []byte
 	accessList AccessList
 	isFake     bool
+	mint       *big.Int
 }
 
 func NewMessage(from common.Address, to *common.Address, nonce uint64, amount *big.Int, gasLimit uint64, gasPrice, gasFeeCap, gasTipCap *big.Int, data []byte, accessList AccessList, isFake bool) Message {
@@ -605,6 +631,7 @@ func NewMessage(from common.Address, to *common.Address, nonce uint64, amount *b
 		data:       data,
 		accessList: accessList,
 		isFake:     isFake,
+		mint:       big.NewInt(0),
 	}
 }
 
@@ -621,6 +648,9 @@ func (tx *Transaction) AsMessage(s Signer, baseFee *big.Int) (Message, error) {
 		data:       tx.Data(),
 		accessList: tx.AccessList(),
 		isFake:     false,
+	}
+	if dep, ok := tx.inner.(*DepositTx); ok {
+		msg.mint = dep.Mint
 	}
 	// If baseFee provided, set gasPrice to effectiveGasPrice.
 	if baseFee != nil {
@@ -642,6 +672,7 @@ func (m Message) Nonce() uint64          { return m.nonce }
 func (m Message) Data() []byte           { return m.data }
 func (m Message) AccessList() AccessList { return m.accessList }
 func (m Message) IsFake() bool           { return m.isFake }
+func (m Message) Mint() *big.Int         { return m.mint }
 
 // copyAddressPtr copies an address.
 func copyAddressPtr(a *common.Address) *common.Address {

--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -42,6 +42,12 @@ type txJSON struct {
 	S                    *hexutil.Big    `json:"s"`
 	To                   *common.Address `json:"to"`
 
+	// Deposit transaction fields
+	BlockHeight      *hexutil.Uint64 `json:"blockHeight,omitempty"`
+	TransactionIndex *hexutil.Uint64 `json:"transactionIndex,omitempty"`
+	From             *common.Address `json:"from,omitempty"`
+	Mint             *hexutil.Big    `json:"mint,omitempty"`
+
 	// Access list transaction fields:
 	ChainID    *hexutil.Big `json:"chainId,omitempty"`
 	AccessList *AccessList  `json:"accessList,omitempty"`
@@ -94,6 +100,18 @@ func (t *Transaction) MarshalJSON() ([]byte, error) {
 		enc.V = (*hexutil.Big)(tx.V)
 		enc.R = (*hexutil.Big)(tx.R)
 		enc.S = (*hexutil.Big)(tx.S)
+	case *DepositTx:
+		enc.Gas = (*hexutil.Uint64)(&tx.Gas)
+		enc.Value = (*hexutil.Big)(tx.Value)
+		enc.Data = (*hexutil.Bytes)(&tx.Data)
+		enc.To = t.To()
+		enc.BlockHeight = (*hexutil.Uint64)(&tx.BlockHeight)
+		enc.TransactionIndex = (*hexutil.Uint64)(&tx.TransactionIndex)
+		enc.From = &tx.From
+		if tx.Mint != nil {
+			enc.Mint = (*hexutil.Big)(tx.Mint)
+		}
+		// other fields will show up as null.
 	}
 	return json.Marshal(&enc)
 }
@@ -262,7 +280,39 @@ func (t *Transaction) UnmarshalJSON(input []byte) error {
 				return err
 			}
 		}
-
+	case DepositTxType:
+		if dec.AccessList != nil || dec.V != nil || dec.R != nil || dec.S != nil || dec.MaxFeePerGas != nil ||
+			dec.MaxPriorityFeePerGas != nil || dec.GasPrice != nil || (dec.Nonce != nil && *dec.Nonce != 0) {
+			return errors.New("unexpected field(s) in deposit transaction")
+		}
+		var itx DepositTx
+		inner = &itx
+		if dec.To != nil {
+			itx.To = dec.To
+		}
+		itx.Gas = uint64(*dec.Gas)
+		if dec.Value == nil {
+			return errors.New("missing required field 'value' in transaction")
+		}
+		itx.Value = (*big.Int)(dec.Value)
+		// mint may be omitted or nil if there is nothing to mint.
+		itx.Mint = (*big.Int)(dec.Mint)
+		if dec.Data == nil {
+			return errors.New("missing required field 'input' in transaction")
+		}
+		itx.Data = *dec.Data
+		if dec.From == nil {
+			return errors.New("missing required field 'from' in transaction")
+		}
+		itx.From = *dec.From
+		if dec.BlockHeight == nil {
+			return errors.New("missing required field 'blockHeight' in transaction")
+		}
+		itx.BlockHeight = uint64(*dec.BlockHeight)
+		if dec.TransactionIndex == nil {
+			return errors.New("missing required field 'transactionIndex' in transaction")
+		}
+		itx.TransactionIndex = uint64(*dec.TransactionIndex)
 	default:
 		return ErrTxTypeNotSupported
 	}

--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -43,10 +43,9 @@ type txJSON struct {
 	To                   *common.Address `json:"to"`
 
 	// Deposit transaction fields
-	BlockHeight      *hexutil.Uint64 `json:"blockHeight,omitempty"`
-	TransactionIndex *hexutil.Uint64 `json:"transactionIndex,omitempty"`
-	From             *common.Address `json:"from,omitempty"`
-	Mint             *hexutil.Big    `json:"mint,omitempty"`
+	SourceHash *common.Hash    `json:"sourceHash,omitempty"`
+	From       *common.Address `json:"from,omitempty"`
+	Mint       *hexutil.Big    `json:"mint,omitempty"`
 
 	// Access list transaction fields:
 	ChainID    *hexutil.Big `json:"chainId,omitempty"`
@@ -105,8 +104,7 @@ func (t *Transaction) MarshalJSON() ([]byte, error) {
 		enc.Value = (*hexutil.Big)(tx.Value)
 		enc.Data = (*hexutil.Bytes)(&tx.Data)
 		enc.To = t.To()
-		enc.BlockHeight = (*hexutil.Uint64)(&tx.BlockHeight)
-		enc.TransactionIndex = (*hexutil.Uint64)(&tx.TransactionIndex)
+		enc.SourceHash = &tx.SourceHash
 		enc.From = &tx.From
 		if tx.Mint != nil {
 			enc.Mint = (*hexutil.Big)(tx.Mint)
@@ -305,14 +303,10 @@ func (t *Transaction) UnmarshalJSON(input []byte) error {
 			return errors.New("missing required field 'from' in transaction")
 		}
 		itx.From = *dec.From
-		if dec.BlockHeight == nil {
-			return errors.New("missing required field 'blockHeight' in transaction")
+		if dec.SourceHash == nil {
+			return errors.New("missing required field 'sourceHash' in transaction")
 		}
-		itx.BlockHeight = uint64(*dec.BlockHeight)
-		if dec.TransactionIndex == nil {
-			return errors.New("missing required field 'transactionIndex' in transaction")
-		}
-		itx.TransactionIndex = uint64(*dec.TransactionIndex)
+		itx.SourceHash = *dec.SourceHash
 	default:
 		return ErrTxTypeNotSupported
 	}

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -182,6 +182,9 @@ func NewLondonSigner(chainId *big.Int) Signer {
 }
 
 func (s londonSigner) Sender(tx *Transaction) (common.Address, error) {
+	if tx.Type() == DepositTxType {
+		return tx.inner.(*DepositTx).From, nil
+	}
 	if tx.Type() != DynamicFeeTxType {
 		return s.eip2930Signer.Sender(tx)
 	}
@@ -201,6 +204,9 @@ func (s londonSigner) Equal(s2 Signer) bool {
 }
 
 func (s londonSigner) SignatureValues(tx *Transaction, sig []byte) (R, S, V *big.Int, err error) {
+	if tx.Type() == DepositTxType {
+		return nil, nil, nil, fmt.Errorf("deposits do not have a signature")
+	}
 	txdata, ok := tx.inner.(*DynamicFeeTx)
 	if !ok {
 		return s.eip2930Signer.SignatureValues(tx, sig)
@@ -218,6 +224,9 @@ func (s londonSigner) SignatureValues(tx *Transaction, sig []byte) (R, S, V *big
 // Hash returns the hash to be signed by the sender.
 // It does not uniquely identify the transaction.
 func (s londonSigner) Hash(tx *Transaction) common.Hash {
+	if tx.Type() == DepositTxType {
+		panic("deposits cannot be signed and do not have a signing hash")
+	}
 	if tx.Type() != DynamicFeeTxType {
 		return s.eip2930Signer.Hash(tx)
 	}

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -200,15 +200,24 @@ func (api *ConsensusAPI) ForkchoiceUpdatedV1(update beacon.ForkchoiceStateV1, pa
 	// sealed by the beacon client. The payload will be requested later, and we
 	// might replace it arbitrarily many times in between.
 	if payloadAttributes != nil {
+		// Decode deposits. TODO: How to handle tx validity.
+		deposits := make(types.Transactions, 0, len(payloadAttributes.Transactions))
+		for i, otx := range payloadAttributes.Transactions {
+			var tx types.Transaction
+			if err := tx.UnmarshalBinary(otx); err != nil {
+				return beacon.STATUS_INVALID, fmt.Errorf("transaction %d is not valid: %v", i, err)
+			}
+			deposits = append(deposits, &tx)
+		}
 		// Create an empty block first which can be used as a fallback
-		empty, err := api.eth.Miner().GetSealingBlockSync(update.HeadBlockHash, payloadAttributes.Timestamp, payloadAttributes.SuggestedFeeRecipient, payloadAttributes.Random, true)
+		empty, err := api.eth.Miner().GetSealingBlockSync(update.HeadBlockHash, payloadAttributes.Timestamp, payloadAttributes.SuggestedFeeRecipient, payloadAttributes.Random, true, deposits)
 		if err != nil {
 			log.Error("Failed to create empty sealing payload", "err", err)
 			return valid(nil), beacon.InvalidPayloadAttributes.With(err)
 		}
 		// Send a request to generate a full block in the background.
 		// The result can be obtained via the returned channel.
-		resCh, err := api.eth.Miner().GetSealingBlockAsync(update.HeadBlockHash, payloadAttributes.Timestamp, payloadAttributes.SuggestedFeeRecipient, payloadAttributes.Random, false)
+		resCh, err := api.eth.Miner().GetSealingBlockAsync(update.HeadBlockHash, payloadAttributes.Timestamp, payloadAttributes.SuggestedFeeRecipient, payloadAttributes.Random, false, deposits)
 		if err != nil {
 			log.Error("Failed to create async sealing payload", "err", err)
 			return valid(nil), beacon.InvalidPayloadAttributes.With(err)

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -200,24 +200,29 @@ func (api *ConsensusAPI) ForkchoiceUpdatedV1(update beacon.ForkchoiceStateV1, pa
 	// sealed by the beacon client. The payload will be requested later, and we
 	// might replace it arbitrarily many times in between.
 	if payloadAttributes != nil {
-		// Decode deposits. TODO: How to handle tx validity.
-		deposits := make(types.Transactions, 0, len(payloadAttributes.Transactions))
+		// Decode forceTxs. TODO: How to handle tx validity.
+		forceTxs := make(types.Transactions, 0, len(payloadAttributes.Transactions))
 		for i, otx := range payloadAttributes.Transactions {
 			var tx types.Transaction
 			if err := tx.UnmarshalBinary(otx); err != nil {
 				return beacon.STATUS_INVALID, fmt.Errorf("transaction %d is not valid: %v", i, err)
 			}
-			deposits = append(deposits, &tx)
+			forceTxs = append(forceTxs, &tx)
 		}
 		// Create an empty block first which can be used as a fallback
-		empty, err := api.eth.Miner().GetSealingBlockSync(update.HeadBlockHash, payloadAttributes.Timestamp, payloadAttributes.SuggestedFeeRecipient, payloadAttributes.Random, true, deposits)
+		empty, err := api.eth.Miner().GetSealingBlockSync(update.HeadBlockHash, payloadAttributes.Timestamp, payloadAttributes.SuggestedFeeRecipient, payloadAttributes.Random, true, forceTxs)
 		if err != nil {
 			log.Error("Failed to create empty sealing payload", "err", err)
 			return valid(nil), beacon.InvalidPayloadAttributes.With(err)
 		}
+		if payloadAttributes.NoTxPool {
+			id := computePayloadId(update.HeadBlockHash, payloadAttributes)
+			api.localBlocks.put(id, &payload{block: block, result: nil, done: true}) // we don't let it default to "empty", we just mark the thing as done.
+			return valid(&id), nil
+		}
 		// Send a request to generate a full block in the background.
 		// The result can be obtained via the returned channel.
-		resCh, err := api.eth.Miner().GetSealingBlockAsync(update.HeadBlockHash, payloadAttributes.Timestamp, payloadAttributes.SuggestedFeeRecipient, payloadAttributes.Random, false, deposits)
+		resCh, err := api.eth.Miner().GetSealingBlockAsync(update.HeadBlockHash, payloadAttributes.Timestamp, payloadAttributes.SuggestedFeeRecipient, payloadAttributes.Random, false, forceTxs)
 		if err != nil {
 			log.Error("Failed to create async sealing payload", "err", err)
 			return valid(nil), beacon.InvalidPayloadAttributes.With(err)

--- a/eth/catalyst/api_test.go
+++ b/eth/catalyst/api_test.go
@@ -603,7 +603,7 @@ func TestNewPayloadOnInvalidChain(t *testing.T) {
 }
 
 func assembleBlock(api *ConsensusAPI, parentHash common.Hash, params *beacon.PayloadAttributesV1) (*beacon.ExecutableDataV1, error) {
-	block, err := api.eth.Miner().GetSealingBlockSync(parentHash, params.Timestamp, params.SuggestedFeeRecipient, params.Random, false)
+	block, err := api.eth.Miner().GetSealingBlockSync(parentHash, params.Timestamp, params.SuggestedFeeRecipient, params.Random, false, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -845,7 +845,7 @@ func TestNewPayloadOnInvalidTerminalBlock(t *testing.T) {
 		Random:                crypto.Keccak256Hash([]byte{byte(1)}),
 		SuggestedFeeRecipient: parent.Coinbase(),
 	}
-	empty, err := api.eth.Miner().GetSealingBlockSync(parent.Hash(), params.Timestamp, params.SuggestedFeeRecipient, params.Random, true)
+	empty, err := api.eth.Miner().GetSealingBlockSync(parent.Hash(), params.Timestamp, params.SuggestedFeeRecipient, params.Random, true, nil)
 	if err != nil {
 		t.Fatalf("error preparing payload, err=%v", err)
 	}

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1231,7 +1231,7 @@ type RPCTransaction struct {
 
 	// deposit-tx only
 	BlockHeight *hexutil.Uint64 `json:"blockHeight,omitempty"`
-	Mint        *hexutil.Big    `json:"big,omitempty"`
+	Mint        *hexutil.Big    `json:"mint,omitempty"`
 }
 
 // newRPCTransaction returns a transaction that will serialize to the RPC

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1230,8 +1230,8 @@ type RPCTransaction struct {
 	S                *hexutil.Big      `json:"s"`
 
 	// deposit-tx only
-	BlockHeight *hexutil.Uint64 `json:"blockHeight,omitempty"`
-	Mint        *hexutil.Big    `json:"mint,omitempty"`
+	SourceHash *common.Hash `json:"sourceHash,omitempty"`
+	Mint       *hexutil.Big `json:"mint,omitempty"`
 }
 
 // newRPCTransaction returns a transaction that will serialize to the RPC
@@ -1240,19 +1240,17 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 	signer := types.MakeSigner(config, big.NewInt(0).SetUint64(blockNumber))
 	from, _ := types.Sender(signer, tx)
 	if tx.Type() == types.DepositTxType {
-		idx := tx.TransactionIndex()
-		height := tx.BlockHeight()
+		srcHash := tx.SourceHash()
 		result := &RPCTransaction{
-			Type:             hexutil.Uint64(tx.Type()),
-			From:             from,
-			Gas:              hexutil.Uint64(tx.Gas()),
-			Hash:             tx.Hash(),
-			Input:            hexutil.Bytes(tx.Data()),
-			To:               tx.To(),
-			Value:            (*hexutil.Big)(tx.Value()),
-			Mint:             (*hexutil.Big)(tx.Mint()),
-			TransactionIndex: (*hexutil.Uint64)(&idx),
-			BlockHeight:      (*hexutil.Uint64)(&height),
+			Type:       hexutil.Uint64(tx.Type()),
+			From:       from,
+			Gas:        hexutil.Uint64(tx.Gas()),
+			Hash:       tx.Hash(),
+			Input:      hexutil.Bytes(tx.Data()),
+			To:         tx.To(),
+			Value:      (*hexutil.Big)(tx.Value()),
+			Mint:       (*hexutil.Big)(tx.Mint()),
+			SourceHash: (*common.Hash)(&srcHash),
 		}
 		if blockHash != (common.Hash{}) {
 			result.BlockHash = &blockHash

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1228,6 +1228,10 @@ type RPCTransaction struct {
 	V                *hexutil.Big      `json:"v"`
 	R                *hexutil.Big      `json:"r"`
 	S                *hexutil.Big      `json:"s"`
+
+	// deposit-tx only
+	BlockHeight *hexutil.Uint64 `json:"blockHeight,omitempty"`
+	Mint        *hexutil.Big    `json:"big,omitempty"`
 }
 
 // newRPCTransaction returns a transaction that will serialize to the RPC
@@ -1235,6 +1239,28 @@ type RPCTransaction struct {
 func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber uint64, index uint64, baseFee *big.Int, config *params.ChainConfig) *RPCTransaction {
 	signer := types.MakeSigner(config, big.NewInt(0).SetUint64(blockNumber))
 	from, _ := types.Sender(signer, tx)
+	if tx.Type() == types.DepositTxType {
+		idx := tx.TransactionIndex()
+		height := tx.BlockHeight()
+		result := &RPCTransaction{
+			Type:             hexutil.Uint64(tx.Type()),
+			From:             from,
+			Gas:              hexutil.Uint64(tx.Gas()),
+			Hash:             tx.Hash(),
+			Input:            hexutil.Bytes(tx.Data()),
+			To:               tx.To(),
+			Value:            (*hexutil.Big)(tx.Value()),
+			Mint:             (*hexutil.Big)(tx.Mint()),
+			TransactionIndex: (*hexutil.Uint64)(&idx),
+			BlockHeight:      (*hexutil.Uint64)(&height),
+		}
+		if blockHash != (common.Hash{}) {
+			result.BlockHash = &blockHash
+			result.BlockNumber = (*hexutil.Big)(new(big.Int).SetUint64(blockNumber))
+			result.TransactionIndex = (*hexutil.Uint64)(&index)
+		}
+		return result
+	}
 	v, r, s := tx.RawSignatureValues()
 	result := &RPCTransaction{
 		Type:     hexutil.Uint64(tx.Type()),

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1250,7 +1250,7 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 			To:         tx.To(),
 			Value:      (*hexutil.Big)(tx.Value()),
 			Mint:       (*hexutil.Big)(tx.Mint()),
-			SourceHash: (*common.Hash)(&srcHash),
+			SourceHash: &srcHash,
 		}
 		if blockHash != (common.Hash{}) {
 			result.BlockHash = &blockHash

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -246,8 +246,8 @@ func (miner *Miner) SubscribePendingLogs(ch chan<- []*types.Log) event.Subscript
 // there is always a result that will be returned through the result channel.
 // The difference is that if the execution fails, the returned result is nil
 // and the concrete error is dropped silently.
-func (miner *Miner) GetSealingBlockAsync(parent common.Hash, timestamp uint64, coinbase common.Address, random common.Hash, noTxs bool) (chan *types.Block, error) {
-	resCh, _, err := miner.worker.getSealingBlock(parent, timestamp, coinbase, random, noTxs)
+func (miner *Miner) GetSealingBlockAsync(parent common.Hash, timestamp uint64, coinbase common.Address, random common.Hash, noTxs bool, deposits types.Transactions) (chan *types.Block, error) {
+	resCh, _, err := miner.worker.getSealingBlock(parent, timestamp, coinbase, random, noTxs, deposits)
 	if err != nil {
 		return nil, err
 	}
@@ -257,8 +257,8 @@ func (miner *Miner) GetSealingBlockAsync(parent common.Hash, timestamp uint64, c
 // GetSealingBlockSync creates a sealing block according to the given parameters.
 // If the generation is failed or the underlying work is already closed, an error
 // will be returned.
-func (miner *Miner) GetSealingBlockSync(parent common.Hash, timestamp uint64, coinbase common.Address, random common.Hash, noTxs bool) (*types.Block, error) {
-	resCh, errCh, err := miner.worker.getSealingBlock(parent, timestamp, coinbase, random, noTxs)
+func (miner *Miner) GetSealingBlockSync(parent common.Hash, timestamp uint64, coinbase common.Address, random common.Hash, noTxs bool, deposits types.Transactions) (*types.Block, error) {
+	resCh, errCh, err := miner.worker.getSealingBlock(parent, timestamp, coinbase, random, noTxs, deposits)
 	if err != nil {
 		return nil, err
 	}

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -246,8 +246,8 @@ func (miner *Miner) SubscribePendingLogs(ch chan<- []*types.Log) event.Subscript
 // there is always a result that will be returned through the result channel.
 // The difference is that if the execution fails, the returned result is nil
 // and the concrete error is dropped silently.
-func (miner *Miner) GetSealingBlockAsync(parent common.Hash, timestamp uint64, coinbase common.Address, random common.Hash, noTxs bool, deposits types.Transactions) (chan *types.Block, error) {
-	resCh, _, err := miner.worker.getSealingBlock(parent, timestamp, coinbase, random, noTxs, deposits)
+func (miner *Miner) GetSealingBlockAsync(parent common.Hash, timestamp uint64, coinbase common.Address, random common.Hash, noTxs bool, forceTxs types.Transactions) (chan *types.Block, error) {
+	resCh, _, err := miner.worker.getSealingBlock(parent, timestamp, coinbase, random, noTxs, forceTxs)
 	if err != nil {
 		return nil, err
 	}
@@ -257,8 +257,8 @@ func (miner *Miner) GetSealingBlockAsync(parent common.Hash, timestamp uint64, c
 // GetSealingBlockSync creates a sealing block according to the given parameters.
 // If the generation is failed or the underlying work is already closed, an error
 // will be returned.
-func (miner *Miner) GetSealingBlockSync(parent common.Hash, timestamp uint64, coinbase common.Address, random common.Hash, noTxs bool, deposits types.Transactions) (*types.Block, error) {
-	resCh, errCh, err := miner.worker.getSealingBlock(parent, timestamp, coinbase, random, noTxs, deposits)
+func (miner *Miner) GetSealingBlockSync(parent common.Hash, timestamp uint64, coinbase common.Address, random common.Hash, noTxs bool, forceTxs types.Transactions) (*types.Block, error) {
+	resCh, errCh, err := miner.worker.getSealingBlock(parent, timestamp, coinbase, random, noTxs, forceTxs)
 	if err != nil {
 		return nil, err
 	}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -970,6 +970,8 @@ type generateParams struct {
 	noUncle    bool           // Flag whether the uncle block inclusion is allowed
 	noExtra    bool           // Flag whether the extra field assignment is allowed
 	noTxs      bool           // Flag whether an empty block without any transaction is expected
+
+	deposits types.Transactions // Deposit transactions to include at the start of the block
 }
 
 // prepareWork constructs the sealing task according to the given parameters,
@@ -1084,14 +1086,72 @@ func (w *worker) fillTransactions(interrupt *int32, env *environment) error {
 }
 
 // generateWork generates a sealing block based on the given parameters.
-func (w *worker) generateWork(params *generateParams) (*types.Block, error) {
-	work, err := w.prepareWork(params)
+func (w *worker) generateWork(genParams *generateParams) (*types.Block, error) {
+	work, err := w.prepareWork(genParams)
 	if err != nil {
 		return nil, err
 	}
 	defer work.discard()
 
-	if !params.noTxs {
+	// Hacked in running deposits first
+	gasLimit := work.header.GasLimit
+	if work.gasPool == nil {
+		work.gasPool = new(core.GasPool).AddGas(gasLimit)
+	}
+
+	for _, tx := range genParams.deposits {
+		// If we don't have enough gas for any further transactions then we're done
+		if work.gasPool.Gas() < params.TxGas {
+			log.Trace("Not enough gas for further transactions", "have", work.gasPool, "want", params.TxGas)
+			break
+		}
+
+		// Error may be ignored here. The error has already been checked
+		// during transaction acceptance is the transaction pool.
+		//
+		// We use the eip155 signer regardless of the current hf.
+		from, _ := types.Sender(work.signer, tx)
+		// Check whether the tx is replay protected. If we're not in the EIP155 hf
+		// phase, start ignoring the sender until we do.
+		if tx.Protected() && !w.chainConfig.IsEIP155(work.header.Number) {
+			log.Trace("Ignoring reply protected transaction", "hash", tx.Hash(), "eip155", w.chainConfig.EIP155Block)
+			continue
+		}
+		// Start executing the transaction
+		work.state.Prepare(tx.Hash(), work.tcount)
+
+		_, err := w.commitTransaction(work, tx)
+		switch {
+		case errors.Is(err, core.ErrGasLimitReached):
+			// Pop the current out-of-gas transaction without shifting in the next from the account
+			log.Trace("Gas limit exceeded for current block", "sender", from)
+
+		case errors.Is(err, core.ErrNonceTooLow):
+			// New head notification data race between the transaction pool and miner, shift
+			log.Trace("Skipping transaction with low nonce", "sender", from, "nonce", tx.Nonce())
+
+		case errors.Is(err, core.ErrNonceTooHigh):
+			// Reorg notification data race between the transaction pool and miner, skip account =
+			log.Trace("Skipping account with high nonce", "sender", from, "nonce", tx.Nonce())
+		case errors.Is(err, nil):
+			// Everything ok, collect the logs and shift in the next transaction from the same account
+			// coalescedLogs = append(coalescedLogs, logs...)
+			work.tcount++
+
+		case errors.Is(err, core.ErrTxTypeNotSupported):
+			// Pop the unsupported transaction without shifting in the next from the account
+			log.Trace("Skipping unsupported transaction type", "sender", from, "type", tx.Type())
+
+		default:
+			// Strange error, discard the transaction and get the next in line (note, the
+			// nonce-too-high clause will prevent us from executing in vain).
+			log.Debug("Transaction failed, account skipped", "hash", tx.Hash(), "err", err)
+		}
+	}
+
+	// Deposits done, fill rest of block with transactions
+
+	if !genParams.noTxs {
 		w.fillTransactions(nil, work)
 	}
 	return w.engine.FinalizeAndAssemble(w.chain, work.header, work.state, work.txs, work.unclelist(), work.receipts)
@@ -1180,7 +1240,7 @@ func (w *worker) commit(env *environment, interval func(), update bool, start ti
 // getSealingBlock generates the sealing block based on the given parameters.
 // The generation result will be passed back via the given channel no matter
 // the generation itself succeeds or not.
-func (w *worker) getSealingBlock(parent common.Hash, timestamp uint64, coinbase common.Address, random common.Hash, noTxs bool) (chan *types.Block, chan error, error) {
+func (w *worker) getSealingBlock(parent common.Hash, timestamp uint64, coinbase common.Address, random common.Hash, noTxs bool, deposits types.Transactions) (chan *types.Block, chan error, error) {
 	var (
 		resCh = make(chan *types.Block, 1)
 		errCh = make(chan error, 1)
@@ -1195,6 +1255,7 @@ func (w *worker) getSealingBlock(parent common.Hash, timestamp uint64, coinbase 
 			noUncle:    true,
 			noExtra:    true,
 			noTxs:      noTxs,
+			deposits:   deposits,
 		},
 		result: resCh,
 		err:    errCh,

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -971,7 +971,7 @@ type generateParams struct {
 	noExtra    bool           // Flag whether the extra field assignment is allowed
 	noTxs      bool           // Flag whether an empty block without any transaction is expected
 
-	deposits types.Transactions // Deposit transactions to include at the start of the block
+	forceTxs types.Transactions // Transactions to force-include at the start of the block
 }
 
 // prepareWork constructs the sealing task according to the given parameters,
@@ -1093,13 +1093,12 @@ func (w *worker) generateWork(genParams *generateParams) (*types.Block, error) {
 	}
 	defer work.discard()
 
-	// Hacked in running deposits first
 	gasLimit := work.header.GasLimit
 	if work.gasPool == nil {
 		work.gasPool = new(core.GasPool).AddGas(gasLimit)
 	}
 
-	for _, tx := range genParams.deposits {
+	for _, tx := range genParams.forceTxs {
 		// If we don't have enough gas for any further transactions then we're done
 		if work.gasPool.Gas() < params.TxGas {
 			log.Trace("Not enough gas for further transactions", "have", work.gasPool, "want", params.TxGas)
@@ -1240,7 +1239,7 @@ func (w *worker) commit(env *environment, interval func(), update bool, start ti
 // getSealingBlock generates the sealing block based on the given parameters.
 // The generation result will be passed back via the given channel no matter
 // the generation itself succeeds or not.
-func (w *worker) getSealingBlock(parent common.Hash, timestamp uint64, coinbase common.Address, random common.Hash, noTxs bool, deposits types.Transactions) (chan *types.Block, chan error, error) {
+func (w *worker) getSealingBlock(parent common.Hash, timestamp uint64, coinbase common.Address, random common.Hash, noTxs bool, forceTxs types.Transactions) (chan *types.Block, chan error, error) {
 	var (
 		resCh = make(chan *types.Block, 1)
 		errCh = make(chan error, 1)
@@ -1255,7 +1254,7 @@ func (w *worker) getSealingBlock(parent common.Hash, timestamp uint64, coinbase 
 			noUncle:    true,
 			noExtra:    true,
 			noTxs:      noTxs,
-			deposits:   deposits,
+			forceTxs:   forceTxs,
 		},
 		result: resCh,
 		err:    errCh,

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -638,7 +638,7 @@ func testGetSealingWork(t *testing.T, chainConfig *params.ChainConfig, engine co
 
 	// This API should work even when the automatic sealing is not enabled
 	for _, c := range cases {
-		resChan, errChan, _ := w.getSealingBlock(c.parent, timestamp, c.coinbase, c.random, false)
+		resChan, errChan, _ := w.getSealingBlock(c.parent, timestamp, c.coinbase, c.random, false, nil)
 		block := <-resChan
 		err := <-errChan
 		if c.expectErr {
@@ -656,7 +656,7 @@ func testGetSealingWork(t *testing.T, chainConfig *params.ChainConfig, engine co
 	// This API should work even when the automatic sealing is enabled
 	w.start()
 	for _, c := range cases {
-		resChan, errChan, _ := w.getSealingBlock(c.parent, timestamp, c.coinbase, c.random, false)
+		resChan, errChan, _ := w.getSealingBlock(c.parent, timestamp, c.coinbase, c.random, false, nil)
 		block := <-resChan
 		err := <-errChan
 		if c.expectErr {

--- a/node/config.go
+++ b/node/config.go
@@ -201,7 +201,7 @@ type Config struct {
 	// AllowUnprotectedTxs allows non EIP-155 protected transactions to be send over RPC.
 	AllowUnprotectedTxs bool `toml:",omitempty"`
 
-	// JWTSecret is the hex-encoded jwt secret.
+	// JWTSecret is the path to the hex-encoded jwt secret.
 	JWTSecret string `toml:",omitempty"`
 }
 

--- a/node/node.go
+++ b/node/node.go
@@ -667,6 +667,19 @@ func (n *Node) WSEndpoint() string {
 	return "ws://" + n.ws.listenAddr() + n.ws.wsConfig.prefix
 }
 
+// HTTPAuthEndpoint returns the URL of the authenticated HTTP server.
+func (n *Node) HTTPAuthEndpoint() string {
+	return "http://" + n.httpAuth.listenAddr()
+}
+
+// WSAuthEndpoint returns the current authenticated JSON-RPC over WebSocket endpoint.
+func (n *Node) WSAuthEndpoint() string {
+	if n.httpAuth.wsAllowed() {
+		return "ws://" + n.httpAuth.listenAddr() + n.httpAuth.wsConfig.prefix
+	}
+	return "ws://" + n.wsAuth.listenAddr() + n.wsAuth.wsConfig.prefix
+}
+
 // EventMux retrieves the event multiplexer used by all the network services in
 // the current protocol stack.
 func (n *Node) EventMux() *event.TypeMux {

--- a/node/node_auth_test.go
+++ b/node/node_auth_test.go
@@ -153,12 +153,12 @@ func TestAuthEndpoints(t *testing.T) {
 		t.Fatalf("expected http and auth-http endpoints to be different, got: %q and %q", a, b)
 	}
 
-	goodAuth := rpc.NewJWTAuthProvider(secret[:])
+	goodAuth := rpc.NewJWTAuthProvider(secret)
 	var otherSecret [32]byte
 	if _, err := crand.Read(otherSecret[:]); err != nil {
 		t.Fatalf("failed to create jwt secret: %v", err)
 	}
-	badAuth := rpc.NewJWTAuthProvider(otherSecret[:])
+	badAuth := rpc.NewJWTAuthProvider(otherSecret)
 	noneAuth := TestAuthProvider(func(header *http.Header) error {
 		token := jwt.NewWithClaims(jwt.SigningMethodNone, jwt.MapClaims{
 			"iat": time.Now().Unix(),

--- a/node/node_auth_test.go
+++ b/node/node_auth_test.go
@@ -1,0 +1,240 @@
+// Copyright 2022 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package node
+
+import (
+	"context"
+	crand "crypto/rand"
+	"fmt"
+	"net/http"
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/golang-jwt/jwt/v4"
+)
+
+type helloRPC string
+
+func (ta helloRPC) HelloWorld() (string, error) {
+	return string(ta), nil
+}
+
+type TestAuthProvider func(header *http.Header) error
+
+func (fn TestAuthProvider) AddAuthHeader(header *http.Header) error {
+	return fn(header)
+}
+
+type authTest struct {
+	name            string
+	endpoint        string
+	prov            rpc.HeaderAuthProvider
+	expectDialFail  bool
+	expectCall1Fail bool
+	expectCall2Fail bool
+}
+
+func (at *authTest) Run(t *testing.T) {
+	ctx := context.Background()
+	cl, err := rpc.DialWithAuth(ctx, at.endpoint, at.prov)
+	if at.expectDialFail {
+		if err == nil {
+			t.Fatal("expected initial dial to fail")
+		} else {
+			return
+		}
+	}
+	if err != nil {
+		t.Fatalf("failed to dial rpc endpoint: %v", err)
+	}
+	var x string
+	err = cl.CallContext(ctx, &x, "engine_helloWorld")
+	if at.expectCall1Fail {
+		if err == nil {
+			t.Fatal("expected call 1 to fail")
+		} else {
+			return
+		}
+	}
+	if err != nil {
+		t.Fatalf("failed to call rpc endpoint: %v", err)
+	}
+	if x != "hello engine" {
+		t.Fatalf("method was silent but did not return expected value: %q", x)
+	}
+	err = cl.CallContext(ctx, &x, "eth_helloWorld")
+	if at.expectCall2Fail {
+		if err == nil {
+			t.Fatal("expected call 2 to fail")
+		} else {
+			return
+		}
+	}
+	if err != nil {
+		t.Fatalf("failed to call rpc endpoint: %v", err)
+	}
+	if x != "hello eth" {
+		t.Fatalf("method was silent but did not return expected value: %q", x)
+	}
+}
+
+func TestAuthEndpoints(t *testing.T) {
+	var secret [32]byte
+	if _, err := crand.Read(secret[:]); err != nil {
+		t.Fatalf("failed to create jwt secret: %v", err)
+	}
+	// Geth must read it from a file, and does not support in-memory JWT secrets, so we create a temporary file.
+	jwtPath := path.Join(t.TempDir(), "jwt_secret")
+	if err := os.WriteFile(jwtPath, []byte(hexutil.Encode(secret[:])), 0600); err != nil {
+		t.Fatalf("failed to prepare jwt secret file: %v", err)
+	}
+	// We get ports assigned by the node automatically
+	conf := &Config{
+		HTTPHost:  "127.0.0.1",
+		HTTPPort:  0,
+		WSHost:    "127.0.0.1",
+		WSPort:    0,
+		AuthAddr:  "127.0.0.1",
+		AuthPort:  0,
+		JWTSecret: jwtPath,
+
+		WSModules:   []string{"eth", "engine"},
+		HTTPModules: []string{"eth", "engine"},
+	}
+	node, err := New(conf)
+	if err != nil {
+		t.Fatalf("could not create a new node: %v", err)
+	}
+	// register dummy apis so we can test the modules are available and reachable with authentication
+	node.RegisterAPIs([]rpc.API{
+		{
+			Namespace:     "engine",
+			Version:       "1.0",
+			Service:       helloRPC("hello engine"),
+			Public:        true,
+			Authenticated: true,
+		},
+		{
+			Namespace:     "eth",
+			Version:       "1.0",
+			Service:       helloRPC("hello eth"),
+			Public:        true,
+			Authenticated: true,
+		},
+	})
+	if err := node.Start(); err != nil {
+		t.Fatalf("failed to start test node: %v", err)
+	}
+	defer node.Close()
+
+	// sanity check we are running different endpoints
+	if a, b := node.WSEndpoint(), node.WSAuthEndpoint(); a == b {
+		t.Fatalf("expected ws and auth-ws endpoints to be different, got: %q and %q", a, b)
+	}
+	if a, b := node.HTTPEndpoint(), node.HTTPAuthEndpoint(); a == b {
+		t.Fatalf("expected http and auth-http endpoints to be different, got: %q and %q", a, b)
+	}
+
+	goodAuth := rpc.NewJWTAuthProvider(secret[:])
+	var otherSecret [32]byte
+	if _, err := crand.Read(otherSecret[:]); err != nil {
+		t.Fatalf("failed to create jwt secret: %v", err)
+	}
+	badAuth := rpc.NewJWTAuthProvider(otherSecret[:])
+	noneAuth := TestAuthProvider(func(header *http.Header) error {
+		token := jwt.NewWithClaims(jwt.SigningMethodNone, jwt.MapClaims{
+			"iat": time.Now().Unix(),
+		})
+		s, err := token.SignedString(secret[:])
+		if err != nil {
+			return fmt.Errorf("failed to create JWT token: %w", err)
+		}
+		header.Add("Authorization", "Bearer "+s)
+		return nil
+	})
+	offsetTimeAuth := func(offset time.Duration) TestAuthProvider {
+		return func(header *http.Header) error {
+			token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+				"iat": time.Now().Add(offset).Unix(),
+			})
+			s, err := token.SignedString(secret[:])
+			if err != nil {
+				return fmt.Errorf("failed to create JWT token: %w", err)
+			}
+			header.Add("Authorization", "Bearer "+s)
+			return nil
+		}
+	}
+	changingAuth := func(provs ...rpc.HeaderAuthProvider) TestAuthProvider {
+		i := 0
+		return func(header *http.Header) error {
+			i += 1
+			if i > len(provs) {
+				i = len(provs)
+			}
+			return provs[i-1].AddAuthHeader(header)
+		}
+	}
+
+	notTooLong := time.Second * 3
+	tooLong := time.Second * 5
+	requestDelay := time.Millisecond * 800
+
+	testCases := []authTest{
+		// Auth works
+		{name: "ws good", endpoint: node.WSAuthEndpoint(), prov: goodAuth, expectCall1Fail: false},
+		{name: "http good", endpoint: node.HTTPAuthEndpoint(), prov: goodAuth, expectCall1Fail: false},
+
+		// Try nil auth
+		{name: "ws nil auth provider", endpoint: node.WSAuthEndpoint(), prov: nil, expectDialFail: true},
+		{name: "http nil auth provider", endpoint: node.HTTPAuthEndpoint(), prov: nil, expectDialFail: true},
+
+		// Try a bad auth
+		{name: "ws bad", endpoint: node.WSAuthEndpoint(), prov: badAuth, expectDialFail: true},      // ws auth is immediate
+		{name: "http bad", endpoint: node.HTTPAuthEndpoint(), prov: badAuth, expectCall1Fail: true}, // http auth is on first call
+
+		// A common mistake with JWT is to allow the "none" algorithm, which is a valid JWT but not secure.
+		{name: "ws none", endpoint: node.WSAuthEndpoint(), prov: noneAuth, expectDialFail: true},
+		{name: "http none", endpoint: node.HTTPAuthEndpoint(), prov: noneAuth, expectCall1Fail: true},
+
+		// claims of 5 seconds or more, older or newer, are not allowed
+		{name: "ws too old", endpoint: node.WSAuthEndpoint(), prov: offsetTimeAuth(-tooLong), expectDialFail: true},
+		{name: "http too old", endpoint: node.HTTPAuthEndpoint(), prov: offsetTimeAuth(-tooLong), expectCall1Fail: true},
+		// note: for it to be too long we need to add a delay, so that once we receive the request, the difference has not dipped below the "tooLong"
+		{name: "ws too new", endpoint: node.WSAuthEndpoint(), prov: offsetTimeAuth(tooLong + requestDelay), expectDialFail: true},
+		{name: "http too new", endpoint: node.HTTPAuthEndpoint(), prov: offsetTimeAuth(tooLong + requestDelay), expectCall1Fail: true},
+
+		// Try offset the time, but stay just within bounds
+		{name: "ws old", endpoint: node.WSAuthEndpoint(), prov: offsetTimeAuth(-notTooLong)},
+		{name: "http old", endpoint: node.HTTPAuthEndpoint(), prov: offsetTimeAuth(-notTooLong)},
+		{name: "ws new", endpoint: node.WSAuthEndpoint(), prov: offsetTimeAuth(notTooLong)},
+		{name: "http new", endpoint: node.HTTPAuthEndpoint(), prov: offsetTimeAuth(notTooLong)},
+
+		// ws only authenticates on initial dial, then continues communication
+		{name: "ws single auth", endpoint: node.WSAuthEndpoint(), prov: changingAuth(goodAuth, badAuth)},
+		{name: "http call fail auth", endpoint: node.HTTPAuthEndpoint(), prov: changingAuth(goodAuth, badAuth), expectCall2Fail: true},
+		{name: "http call fail time", endpoint: node.HTTPAuthEndpoint(), prov: changingAuth(goodAuth, offsetTimeAuth(tooLong+requestDelay)), expectCall2Fail: true},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, testCase.Run)
+	}
+}

--- a/rpc/auth.go
+++ b/rpc/auth.go
@@ -1,0 +1,57 @@
+// Copyright 2022 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package rpc
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+)
+
+// HeaderAuthProvider is an interface for adding JWT Bearer Tokens to HTTP/WS (on the initial upgrade)
+// requests to authenticated APIs.
+// See https://github.com/ethereum/execution-apis/blob/main/src/engine/authentication.md for details
+// about the authentication scheme.
+type HeaderAuthProvider interface {
+	// AddAuthHeader adds an up to date Authorization Bearer token field to the header
+	AddAuthHeader(header *http.Header) error
+}
+
+type JWTAuthProvider struct {
+	secret []byte
+}
+
+// NewJWTAuthProvider creates a new JWT Auth Provider.
+// The secret should not be empty.
+func NewJWTAuthProvider(jwtsecret []byte) *JWTAuthProvider {
+	return &JWTAuthProvider{secret: jwtsecret}
+}
+
+// AddAuthHeader adds a JWT Authorization token to the header
+func (p *JWTAuthProvider) AddAuthHeader(header *http.Header) error {
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"iat": time.Now().Unix(),
+	})
+	s, err := token.SignedString(p.secret)
+	if err != nil {
+		return fmt.Errorf("failed to create JWT token: %w", err)
+	}
+	header.Add("Authorization", "Bearer "+s)
+	return nil
+}

--- a/rpc/auth.go
+++ b/rpc/auth.go
@@ -34,12 +34,12 @@ type HeaderAuthProvider interface {
 }
 
 type JWTAuthProvider struct {
-	secret []byte
+	secret [32]byte
 }
 
 // NewJWTAuthProvider creates a new JWT Auth Provider.
-// The secret should not be empty.
-func NewJWTAuthProvider(jwtsecret []byte) *JWTAuthProvider {
+// The secret MUST be 32 bytes (256 bits) as defined by the Engine-API authentication spec.
+func NewJWTAuthProvider(jwtsecret [32]byte) *JWTAuthProvider {
 	return &JWTAuthProvider{secret: jwtsecret}
 }
 
@@ -48,7 +48,7 @@ func (p *JWTAuthProvider) AddAuthHeader(header *http.Header) error {
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
 		"iat": time.Now().Unix(),
 	})
-	s, err := token.SignedString(p.secret)
+	s, err := token.SignedString(p.secret[:])
 	if err != nil {
 		return fmt.Errorf("failed to create JWT token: %w", err)
 	}

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -186,6 +186,25 @@ func DialContext(ctx context.Context, rawurl string) (*Client, error) {
 	}
 }
 
+func DialWithAuth(ctx context.Context, rawurl string, auth HeaderAuthProvider) (*Client, error) {
+	u, err := url.Parse(rawurl)
+	if err != nil {
+		return nil, err
+	}
+	switch u.Scheme {
+	case "http", "https":
+		return DialHTTPWithAuth(rawurl, auth)
+	case "ws", "wss":
+		return DialWebsocketWithAuth(ctx, rawurl, "", auth)
+	case "stdio":
+		return DialStdIO(ctx)
+	case "":
+		return DialIPC(ctx, rawurl)
+	default:
+		return nil, fmt.Errorf("no known transport for URL scheme %q", u.Scheme)
+	}
+}
+
 // ClientFromContext retrieves the client from the context, if any. This can be used to perform
 // 'reverse calls' in a handler method.
 func ClientFromContext(ctx context.Context) (*Client, bool) {

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -45,6 +45,7 @@ type httpConn struct {
 	closeCh   chan interface{}
 	mu        sync.Mutex // protects headers
 	headers   http.Header
+	auth      HeaderAuthProvider // authorization provider. Must be called on each request as token claims the current time
 }
 
 // httpConn implements ServerCodec, but it is treated specially by Client
@@ -137,6 +138,30 @@ func DialHTTP(endpoint string) (*Client, error) {
 	return DialHTTPWithClient(endpoint, new(http.Client))
 }
 
+// DialHTTPWithAuth creates a new authenticated RPC client that connects to an RPC server over HTTP.
+func DialHTTPWithAuth(endpoint string, auth HeaderAuthProvider) (*Client, error) {
+	// Sanity check URL so we don't end up with a client that will fail every request.
+	_, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, err
+	}
+	client := new(http.Client)
+	initctx := context.Background()
+	headers := make(http.Header, 2)
+	headers.Set("accept", contentType)
+	headers.Set("content-type", contentType)
+	return newClient(initctx, func(context.Context) (ServerCodec, error) {
+		hc := &httpConn{
+			client:  client,
+			headers: headers,
+			url:     endpoint,
+			closeCh: make(chan interface{}),
+			auth:    auth,
+		}
+		return hc, nil
+	})
+}
+
 func (c *Client) sendHTTP(ctx context.Context, op *requestOp, msg interface{}) error {
 	hc := c.writeConn.(*httpConn)
 	respBody, err := hc.doRequest(ctx, msg)
@@ -186,6 +211,12 @@ func (hc *httpConn) doRequest(ctx context.Context, msg interface{}) (io.ReadClos
 	hc.mu.Lock()
 	req.Header = hc.headers.Clone()
 	hc.mu.Unlock()
+	if hc.auth != nil {
+		err = hc.auth.AddAuthHeader(&req.Header)
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	// do request
 	resp, err := hc.client.Do(req)

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -140,6 +140,9 @@ func DialHTTP(endpoint string) (*Client, error) {
 
 // DialHTTPWithAuth creates a new authenticated RPC client that connects to an RPC server over HTTP.
 func DialHTTPWithAuth(endpoint string, auth HeaderAuthProvider) (*Client, error) {
+	if auth == nil {
+		return nil, errors.New("cannot dial http endpoint with auth without auth-provider")
+	}
 	// Sanity check URL so we don't end up with a client that will fail every request.
 	_, err := url.Parse(endpoint)
 	if err != nil {
@@ -212,8 +215,7 @@ func (hc *httpConn) doRequest(ctx context.Context, msg interface{}) (io.ReadClos
 	req.Header = hc.headers.Clone()
 	hc.mu.Unlock()
 	if hc.auth != nil {
-		err = hc.auth.AddAuthHeader(&req.Header)
-		if err != nil {
+		if err := hc.auth.AddAuthHeader(&req.Header); err != nil {
 			return nil, err
 		}
 	}

--- a/rpc/websocket.go
+++ b/rpc/websocket.go
@@ -184,7 +184,7 @@ func parseOriginURL(origin string) (string, string, string, error) {
 // DialWebsocketWithDialer creates a new RPC client that communicates with a JSON-RPC server
 // that is listening on the given endpoint using the provided dialer.
 func DialWebsocketWithDialer(ctx context.Context, endpoint, origin string, dialer websocket.Dialer) (*Client, error) {
-	endpoint, header, err := wsClientHeaders(endpoint, origin)
+	endpoint, header, err := wsClientHeaders(endpoint, origin, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -215,7 +215,36 @@ func DialWebsocket(ctx context.Context, endpoint, origin string) (*Client, error
 	return DialWebsocketWithDialer(ctx, endpoint, origin, dialer)
 }
 
-func wsClientHeaders(endpoint, origin string) (string, http.Header, error) {
+// DialWebsocketWithAuth creates a new RPC client that communicates with a JSON-RPC server
+// that is listening on the given endpoint. It uses the HeaderAuthProvider to authenticate
+// the initial HTTP connection/upgrade.
+//
+// The context is used for the initial connection establishment. It does not
+// affect subsequent interactions with the client.
+func DialWebsocketWithAuth(ctx context.Context, endpoint, origin string, auth HeaderAuthProvider) (*Client, error) {
+	endpoint, header, err := wsClientHeaders(endpoint, origin, auth)
+	if err != nil {
+		return nil, err
+	}
+	dialer := websocket.Dialer{
+		ReadBufferSize:  wsReadBuffer,
+		WriteBufferSize: wsWriteBuffer,
+		WriteBufferPool: wsBufferPool,
+	}
+	return newClient(ctx, func(ctx context.Context) (ServerCodec, error) {
+		conn, resp, err := dialer.DialContext(ctx, endpoint, header)
+		if err != nil {
+			hErr := wsHandshakeError{err: err}
+			if resp != nil {
+				hErr.status = resp.Status
+			}
+			return nil, hErr
+		}
+		return newWebsocketCodec(conn, endpoint, header), nil
+	})
+}
+
+func wsClientHeaders(endpoint, origin string, authProvider HeaderAuthProvider) (string, http.Header, error) {
 	endpointURL, err := url.Parse(endpoint)
 	if err != nil {
 		return endpoint, nil, err
@@ -223,6 +252,13 @@ func wsClientHeaders(endpoint, origin string) (string, http.Header, error) {
 	header := make(http.Header)
 	if origin != "" {
 		header.Add("origin", origin)
+	}
+	// Add JWT Authorization Header if provided
+	if authProvider != nil {
+		err = authProvider.AddAuthHeader(&header)
+		if err != nil {
+			return endpoint, nil, err
+		}
 	}
 	if endpointURL.User != nil {
 		b64auth := base64.StdEncoding.EncodeToString([]byte(endpointURL.User.String()))

--- a/rpc/websocket.go
+++ b/rpc/websocket.go
@@ -19,6 +19,7 @@ package rpc
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -222,6 +223,9 @@ func DialWebsocket(ctx context.Context, endpoint, origin string) (*Client, error
 // The context is used for the initial connection establishment. It does not
 // affect subsequent interactions with the client.
 func DialWebsocketWithAuth(ctx context.Context, endpoint, origin string, auth HeaderAuthProvider) (*Client, error) {
+	if auth == nil {
+		return nil, errors.New("cannot dial websocket endpoint with auth without auth-provider")
+	}
 	endpoint, header, err := wsClientHeaders(endpoint, origin, auth)
 	if err != nil {
 		return nil, err
@@ -255,8 +259,7 @@ func wsClientHeaders(endpoint, origin string, authProvider HeaderAuthProvider) (
 	}
 	// Add JWT Authorization Header if provided
 	if authProvider != nil {
-		err = authProvider.AddAuthHeader(&header)
-		if err != nil {
+		if err := authProvider.AddAuthHeader(&header); err != nil {
 			return endpoint, nil, err
 		}
 	}

--- a/rpc/websocket_test.go
+++ b/rpc/websocket_test.go
@@ -36,7 +36,7 @@ import (
 func TestWebsocketClientHeaders(t *testing.T) {
 	t.Parallel()
 
-	endpoint, header, err := wsClientHeaders("wss://testuser:test-PASS_01@example.com:1234", "https://example.com")
+	endpoint, header, err := wsClientHeaders("wss://testuser:test-PASS_01@example.com:1234", "https://example.com", nil)
 	if err != nil {
 		t.Fatalf("wsGetConfig failed: %s", err)
 	}


### PR DESCRIPTION
Rebased geth (optimism changes from `dev-full-history-start` onto lastest upstream `master`) + cherry-pick the auth testing/utils PR on top of that.

Opening this as "draft" to avoid merging with a merge commit. This rebase would just replace the `dev-full-history-start` branch, and we can squash the range of commits for the single-commit branch.

Side-note: the diff with upstream is small but retaining the full history of our changes made the rebase harder, as I needed to resolve conflicts for each of the api/miner changes.

Side-note 2: upstream geth supports async block building with engine API now, and I've used that change to reduce our diff since we can use the upstream `noTxs` behavior.

Note: the mega diff is because of upstream introducing `signer/fourbyte/4byte.json`: 121790 new lines
