### PR TITLE
rpc-api: add subType to rpc transaction response

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1232,6 +1232,7 @@ type RPCTransaction struct {
 	// deposit-tx only
 	SourceHash *common.Hash `json:"sourceHash,omitempty"`
 	Mint       *hexutil.Big `json:"mint,omitempty"`
+	SubType    *hexutil.Big `json:"subType,omitempty"`
 }
 
 // newRPCTransaction returns a transaction that will serialize to the RPC
@@ -1243,6 +1244,7 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 		srcHash := tx.SourceHash()
 		result := &RPCTransaction{
 			Type:       hexutil.Uint64(tx.Type()),
+			SubType:    (*hexutil.Big)(big.NewInt(types.DepositTxVersionZeroType)),
 			From:       from,
 			Gas:        hexutil.Uint64(tx.Gas()),
 			Hash:       tx.Hash(),


### PR DESCRIPTION
**Description**

The subtype will need to be held on to and propagated
throughout the codebase in the `DepositTransaction` type.
This is a short term fix so that they type is in the API.
Perhaps we can add a field `subType` like this:

```
type DepositTx struct {
    SubType uint8 `rlp:"-"`
    ...
}
```

It will not be rlp encoded this way but will need a setter
and getter.

<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

