### PR TITLE
core: remove deposit-tx sub-type (a.k.a. deposit version byte)

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -25,13 +25,12 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/ethereum/go-ethereum/core/vm"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/prque"
 	"github.com/ethereum/go-ethereum/consensus/misc"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"

--- a/core/types/deposit_tx.go
+++ b/core/types/deposit_tx.go
@@ -22,10 +22,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-const (
-	DepositTxVersionZeroType = iota
-)
-
 const DepositTxType = 0x7E
 
 type DepositTx struct {

--- a/core/types/hashing.go
+++ b/core/types/hashing.go
@@ -53,9 +53,6 @@ func prefixedRlpHash(prefix byte, x interface{}) (h common.Hash) {
 	defer hasherPool.Put(sha)
 	sha.Reset()
 	sha.Write([]byte{prefix})
-	if prefix == DepositTxType {
-		sha.Write([]byte{0})
-	}
 	rlp.Encode(sha, x)
 	sha.Read(h[:])
 	return h

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -40,10 +40,6 @@ var (
 	ErrTxTypeNotSupported   = errors.New("transaction type not supported")
 	ErrGasFeeCapTooLow      = errors.New("fee cap less than base fee")
 	errShortTypedTx         = errors.New("typed transaction too short")
-
-	// Custom Errors for deposits
-	ErrDepositTxTypeNotSupported = errors.New("deposit transaction type not supported")
-	errUnversionedDeposit        = errors.New("deposit transaction does not have version byte")
 )
 
 // Transaction types.
@@ -114,10 +110,6 @@ func (tx *Transaction) EncodeRLP(w io.Writer) error {
 // encodeTyped writes the canonical encoding of a typed transaction to w.
 func (tx *Transaction) encodeTyped(w *bytes.Buffer) error {
 	w.WriteByte(tx.Type())
-	// Only support v0 right now.
-	if tx.Type() == DepositTxType {
-		w.WriteByte(DepositTxVersionZeroType)
-	}
 	return rlp.Encode(w, tx.inner)
 }
 
@@ -199,13 +191,7 @@ func (tx *Transaction) decodeTyped(b []byte) (TxData, error) {
 		return &inner, err
 	case DepositTxType:
 		var inner DepositTx
-		if len(b) < 2 {
-			return nil, errUnversionedDeposit
-		}
-		if b[1] != DepositTxVersionZeroType {
-			return nil, ErrDepositTxTypeNotSupported
-		}
-		err := rlp.DecodeBytes(b[2:], &inner)
+		err := rlp.DecodeBytes(b[1:], &inner)
 		return &inner, err
 	default:
 		return nil, ErrTxTypeNotSupported


### PR DESCRIPTION
This removes the deposit tx sub-byte, in favor of reduced diff, higher compatibility with the expectation of 1 byte + RLP, and no RPC/receipt/tx changes.

If we have to extend the deposit tx with new data we can do so either by adding an optional RLP field, or with a new regular tx type. And deposit behavior can already be hardforked by modifying the rollup-node that creates the tx, or hardforking the geth processing code.


