### PR TITLE
Unmeter the L1 Attributes Transaction

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -811,6 +811,7 @@ type callMsg struct {
 func (m callMsg) From() common.Address         { return m.CallMsg.From }
 func (m callMsg) Nonce() uint64                { return 0 }
 func (m callMsg) IsFake() bool                 { return true }
+func (m callMsg) IsSystemTx() bool             { return false }
 func (m callMsg) To() *common.Address          { return m.CallMsg.To }
 func (m callMsg) GasPrice() *big.Int           { return m.CallMsg.GasPrice }
 func (m callMsg) GasFeeCap() *big.Int          { return m.CallMsg.GasFeeCap }

--- a/core/types/access_list_tx.go
+++ b/core/types/access_list_tx.go
@@ -105,6 +105,7 @@ func (tx *AccessListTx) gasFeeCap() *big.Int    { return tx.GasPrice }
 func (tx *AccessListTx) value() *big.Int        { return tx.Value }
 func (tx *AccessListTx) nonce() uint64          { return tx.Nonce }
 func (tx *AccessListTx) to() *common.Address    { return tx.To }
+func (tx *AccessListTx) isSystemTx() bool       { return false }
 
 func (tx *AccessListTx) rawSignatureValues() (v, r, s *big.Int) {
 	return tx.V, tx.R, tx.S

--- a/core/types/deposit_tx.go
+++ b/core/types/deposit_tx.go
@@ -36,20 +36,24 @@ type DepositTx struct {
 	// Value is transferred from L2 balance, executed after Mint (if any)
 	Value *big.Int
 	// gas limit
-	Gas  uint64
+	Gas uint64
+	// Field indicating if this transaction is exempt from the L2 gas limit.
+	IsSystemTransaction bool
+	// Normal Tx data
 	Data []byte
 }
 
 // copy creates a deep copy of the transaction data and initializes all fields.
 func (tx *DepositTx) copy() TxData {
 	cpy := &DepositTx{
-		SourceHash: tx.SourceHash,
-		From:       tx.From,
-		To:         copyAddressPtr(tx.To),
-		Mint:       nil,
-		Value:      new(big.Int),
-		Gas:        tx.Gas,
-		Data:       common.CopyBytes(tx.Data),
+		SourceHash:          tx.SourceHash,
+		From:                tx.From,
+		To:                  copyAddressPtr(tx.To),
+		Mint:                nil,
+		Value:               new(big.Int),
+		Gas:                 tx.Gas,
+		IsSystemTransaction: tx.IsSystemTransaction,
+		Data:                common.CopyBytes(tx.Data),
 	}
 	if tx.Mint != nil {
 		cpy.Mint = new(big.Int).Set(tx.Mint)
@@ -76,6 +80,7 @@ func (tx *DepositTx) gasPrice() *big.Int     { return new(big.Int) }
 func (tx *DepositTx) value() *big.Int        { return tx.Value }
 func (tx *DepositTx) nonce() uint64          { return DepositsNonce }
 func (tx *DepositTx) to() *common.Address    { return tx.To }
+func (tx *DepositTx) isSystemTx() bool       { return tx.IsSystemTransaction }
 
 func (tx *DepositTx) rawSignatureValues() (v, r, s *big.Int) {
 	return common.Big0, common.Big0, common.Big0

--- a/core/types/dynamic_fee_tx.go
+++ b/core/types/dynamic_fee_tx.go
@@ -93,6 +93,7 @@ func (tx *DynamicFeeTx) gasPrice() *big.Int     { return tx.GasFeeCap }
 func (tx *DynamicFeeTx) value() *big.Int        { return tx.Value }
 func (tx *DynamicFeeTx) nonce() uint64          { return tx.Nonce }
 func (tx *DynamicFeeTx) to() *common.Address    { return tx.To }
+func (tx *DynamicFeeTx) isSystemTx() bool       { return false }
 
 func (tx *DynamicFeeTx) rawSignatureValues() (v, r, s *big.Int) {
 	return tx.V, tx.R, tx.S

--- a/core/types/legacy_tx.go
+++ b/core/types/legacy_tx.go
@@ -102,6 +102,7 @@ func (tx *LegacyTx) gasFeeCap() *big.Int    { return tx.GasPrice }
 func (tx *LegacyTx) value() *big.Int        { return tx.Value }
 func (tx *LegacyTx) nonce() uint64          { return tx.Nonce }
 func (tx *LegacyTx) to() *common.Address    { return tx.To }
+func (tx *LegacyTx) isSystemTx() bool       { return false }
 
 func (tx *LegacyTx) rawSignatureValues() (v, r, s *big.Int) {
 	return tx.V, tx.R, tx.S

--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -46,6 +46,7 @@ type txJSON struct {
 	SourceHash *common.Hash    `json:"sourceHash,omitempty"`
 	From       *common.Address `json:"from,omitempty"`
 	Mint       *hexutil.Big    `json:"mint,omitempty"`
+	IsSystemTx *bool           `json:"isSystemTx,omitempty"`
 
 	// Access list transaction fields:
 	ChainID    *hexutil.Big `json:"chainId,omitempty"`
@@ -109,6 +110,7 @@ func (t *Transaction) MarshalJSON() ([]byte, error) {
 		if tx.Mint != nil {
 			enc.Mint = (*hexutil.Big)(tx.Mint)
 		}
+		enc.IsSystemTx = &tx.IsSystemTransaction
 		// other fields will show up as null.
 	}
 	return json.Marshal(&enc)
@@ -307,6 +309,10 @@ func (t *Transaction) UnmarshalJSON(input []byte) error {
 			return errors.New("missing required field 'sourceHash' in transaction")
 		}
 		itx.SourceHash = *dec.SourceHash
+		// IsSystemTx may be omitted. Defaults to false.
+		if dec.IsSystemTx != nil {
+			itx.IsSystemTransaction = *dec.IsSystemTx
+		}
 	default:
 		return ErrTxTypeNotSupported
 	}

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1265,6 +1265,7 @@ type RPCTransaction struct {
 	// deposit-tx only
 	SourceHash *common.Hash `json:"sourceHash,omitempty"`
 	Mint       *hexutil.Big `json:"mint,omitempty"`
+	IsSystemTx *bool        `json:"isSystemTx,omitempty"`
 }
 
 // newRPCTransaction returns a transaction that will serialize to the RPC
@@ -1274,6 +1275,7 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 	from, _ := types.Sender(signer, tx)
 	if tx.Type() == types.DepositTxType {
 		srcHash := tx.SourceHash()
+		isSystemTx := tx.IsSystemTx()
 		result := &RPCTransaction{
 			Type:       hexutil.Uint64(tx.Type()),
 			From:       from,
@@ -1284,6 +1286,7 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 			Value:      (*hexutil.Big)(tx.Value()),
 			Mint:       (*hexutil.Big)(tx.Mint()),
 			SourceHash: &srcHash,
+			IsSystemTx: &isSystemTx,
 		}
 		if blockHash != (common.Hash{}) {
 			result.BlockHash = &blockHash


### PR DESCRIPTION
**Description**
This adds a new field to the deposit transaction type: `IsSystemTransaction`.
This boolean field indicates that the deposit should be exempt from gas
metering in the block. This specifically means that the gasUsed of the tx
(as recorded in the receipt) is 0 and that it does not remove gas from the
gas pool while processing. It still must have a gas limit & can return out
of gas during normal processing.

This internal transaction field is then threaded through to the Message
type which has a field/function of the same name. This is used to perform
the actual unmetering in the state transition.

**Additional context**
Tested on a local devnet & I confirmed that the L1 Attributes Tx was not recorded
as using gas, but did have a successful receipt status.

**Metadata**
- Fixes ENG-2418
