### PR TITLE
core/types: deposits do not tip, avoid basefee subtraction

### DIFF
--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -378,6 +378,9 @@ func (tx *Transaction) GasTipCapIntCmp(other *big.Int) int {
 // Note: if the effective gasTipCap is negative, this method returns both error
 // the actual negative value, _and_ ErrGasFeeCapTooLow
 func (tx *Transaction) EffectiveGasTip(baseFee *big.Int) (*big.Int, error) {
+	if tx.Type() == DepositTxType {
+		return new(big.Int), nil
+	}
 	if baseFee == nil {
 		return tx.GasTipCap(), nil
 	}


### PR DESCRIPTION
Example how we get negative values in API results:
```
curl http://localhost:9545 \
  -X POST \
  -H "Content-Type: application/json" \
  --data '{"jsonrpc":"2.0","method":"eth_feeHistory","params":["0x1", "0x1", [0.95]],"id":0}'

{"jsonrpc":"2.0","id":0,"result":{"oldestBlock":"0x1","reward":[["-0x342770c0"]],"baseFeePerGas":["0x342770c0","0x2dc3db3f"],"gasUsedRatio":[0.009990244858903442]}}
```
The basefee was being subtracted to compute the priority fee going to the miner, even though deposit transactions do not pay a basefee. This fixes that.

Credit to @lucasgleba + Lattice team for finding this issue.