### PR TITLE
eth,miner: return STATUS_INVALID when failing to process forced txs

### DIFF
--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -276,7 +276,7 @@ func (api *ConsensusAPI) ForkchoiceUpdatedV1(update beacon.ForkchoiceStateV1, pa
 		empty, err := api.eth.Miner().GetSealingBlockSync(update.HeadBlockHash, payloadAttributes.Timestamp, payloadAttributes.SuggestedFeeRecipient, payloadAttributes.Random, true, forceTxs)
 		if err != nil {
 			log.Error("Failed to create empty sealing payload", "err", err)
-			return valid(nil), beacon.InvalidPayloadAttributes.With(err)
+			return beacon.STATUS_INVALID, beacon.InvalidPayloadAttributes.With(err)
 		}
 		if payloadAttributes.NoTxPool {
 			id := computePayloadId(update.HeadBlockHash, payloadAttributes)

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1093,12 +1093,12 @@ func (w *worker) generateWork(params *generateParams) (*types.Block, error) {
 		work.state.Prepare(tx.Hash(), work.tcount)
 		_, err := w.commitTransaction(work, tx)
 		if err != nil {
-			return nil, fmt.Errorf("failed to force-include tx: %s type: %d sender: %s nonce: %d", tx.Hash(), tx.Type(), from, tx.Nonce())
+			return nil, fmt.Errorf("failed to force-include tx: %s, type: %d, sender: %s nonce: %d, err: %w", tx.Hash(), tx.Type(), from, tx.Nonce(), err)
 		}
 		work.tcount++
 	}
 	if !params.noTxs {
-		w.fillTransactions(nil, work)
+		_ = w.fillTransactions(nil, work) // may error on interrupt, but an empty block is fine.
 	}
 	return w.engine.FinalizeAndAssemble(w.chain, work.header, work.state, work.txs, work.unclelist(), work.receipts)
 }


### PR DESCRIPTION
When we fail to prepare a block with just the forced transactions from the request then the request must be bad, and we should return `STATUS_INVALID`. This way we can handle bad L1 data in the rollup node, and not reattempt to process it.

Also update the returned error, so underlying process errors become visible.
