### PR TITLE
verifier: forward tx to sequencer based on flag

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -153,6 +153,7 @@ var (
 		utils.GpoIgnoreGasPriceFlag,
 		utils.MinerNotifyFullFlag,
 		utils.IgnoreLegacyReceiptsFlag,
+		utils.RollupSequencerHTTPFlag,
 		configFileFlag,
 	}, utils.NetworkFlags, utils.DatabasePathFlags)
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -875,6 +875,13 @@ var (
 		Category: flags.GasPriceCategory,
 	}
 
+	// Rollup Flags
+	RollupSequencerHTTPFlag = &cli.StringFlag{
+		Name:     "rollup.sequencerhttp",
+		Usage:    "HTTP endpoint for the sequencer mempool",
+		Category: flags.RollupCategory,
+	}
+
 	// Metrics flags
 	MetricsEnabledFlag = &cli.BoolFlag{
 		Name:     "metrics",
@@ -1848,6 +1855,10 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 		} else {
 			cfg.EthDiscoveryURLs = SplitAndTrim(urls)
 		}
+	}
+	// Only configure sequencer http flag if we're running in verifier mode i.e. --mine is disabled.
+	if ctx.IsSet(RollupSequencerHTTPFlag.Name) && !ctx.IsSet(MiningEnabledFlag.Name) {
+		cfg.RollupSequencerHTTP = ctx.String(RollupSequencerHTTPFlag.Name)
 	}
 	// Override any default configs for hard coded networks.
 	switch {

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -210,6 +210,8 @@ type Config struct {
 
 	// OverrideTerminalTotalDifficultyPassed (TODO: remove after the fork)
 	OverrideTerminalTotalDifficultyPassed *bool `toml:",omitempty"`
+
+	RollupSequencerHTTP string
 }
 
 // CreateConsensusEngine creates a consensus engine for the given chain configuration.

--- a/internal/flags/categories.go
+++ b/internal/flags/categories.go
@@ -31,6 +31,7 @@ const (
 	MinerCategory      = "MINER"
 	GasPriceCategory   = "GAS PRICE ORACLE"
 	VMCategory         = "VIRTUAL MACHINE"
+	RollupCategory     = "ROLLUP NODE"
 	LoggingCategory    = "LOGGING AND DEBUGGING"
 	MetricsCategory    = "METRICS AND STATS"
 	MiscCategory       = "MISC"


### PR DESCRIPTION
**Description**
This PR allows verifiers to optionally forward raw transactions to a sequencer by passing in a HTT URL pointing to the sequencer RPC endpoint.

**Additional context**
This flag is only used if the geth node is running in verifier mode.

**Metadata**
- Fixes #ENG-2214
