### PR TITLE
Add op-geth version in addition to geth version

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -507,7 +507,7 @@ func doDocker(cmdline []string) {
 	case env.Branch == "master":
 		tags = []string{"latest"}
 	case strings.HasPrefix(env.Tag, "v1."):
-		tags = []string{"stable", fmt.Sprintf("release-1.%d", params.VersionMinor), "v" + params.Version}
+		tags = []string{"stable", fmt.Sprintf("release-1.%d", params.OPVersionMinor), "v" + params.Version}
 	}
 	// If architecture specific image builds are requested, build and push them
 	if *image {

--- a/cmd/geth/misccmd.go
+++ b/cmd/geth/misccmd.go
@@ -136,6 +136,7 @@ func version(ctx *cli.Context) error {
 	if gitDate != "" {
 		fmt.Println("Git Commit Date:", gitDate)
 	}
+	fmt.Println("Upstream Version:", params.GethVersionWithMeta)
 	fmt.Println("Architecture:", runtime.GOARCH)
 	fmt.Println("Go Version:", runtime.Version())
 	fmt.Println("Operating System:", runtime.GOOS)

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -296,7 +296,7 @@ func makeExtraData(extra []byte) []byte {
 	if len(extra) == 0 {
 		// create default extradata
 		extra, _ = rlp.EncodeToBytes([]interface{}{
-			uint(params.VersionMajor<<16 | params.VersionMinor<<8 | params.VersionPatch),
+			uint(params.OPVersionMajor<<16 | params.OPVersionMinor<<8 | params.OPVersionPatch),
 			"geth",
 			runtime.Version(),
 			runtime.GOOS,

--- a/params/version.go
+++ b/params/version.go
@@ -21,20 +21,41 @@ import (
 )
 
 const (
+	// Version is the version of upstream geth
 	VersionMajor = 1          // Major version component of the current release
 	VersionMinor = 10         // Minor version component of the current release
 	VersionPatch = 22         // Patch version component of the current release
 	VersionMeta  = "unstable" // Version metadata to append to the version string
+
+	// OPVersion is the version of op-geth
+	OPVersionMajor = 0          // Major version component of the current release
+	OPVersionMinor = 1          // Minor version component of the current release
+	OPVersionPatch = 0          // Patch version component of the current release
+	OPVersionMeta  = "unstable" // Version metadata to append to the version string
 )
 
 // Version holds the textual version string.
 var Version = func() string {
-	return fmt.Sprintf("%d.%d.%d", VersionMajor, VersionMinor, VersionPatch)
+	return fmt.Sprintf("%d.%d.%d", OPVersionMajor, OPVersionMinor, OPVersionPatch)
 }()
 
 // VersionWithMeta holds the textual version string including the metadata.
 var VersionWithMeta = func() string {
 	v := Version
+	if OPVersionMeta != "" {
+		v += "-" + OPVersionMeta
+	}
+	return v
+}()
+
+// GethVersion holds the textual geth version string.
+var GethVersion = func() string {
+	return fmt.Sprintf("%d.%d.%d", VersionMajor, VersionMinor, VersionPatch)
+}()
+
+// GethVersionWithMeta holds the textual geth version string including the metadata.
+var GethVersionWithMeta = func() string {
+	v := GethVersion
 	if VersionMeta != "" {
 		v += "-" + VersionMeta
 	}
@@ -46,8 +67,8 @@ var VersionWithMeta = func() string {
 //      "1.8.13-unstable-21c059b6" for unstable releases
 func ArchiveVersion(gitCommit string) string {
 	vsn := Version
-	if VersionMeta != "stable" {
-		vsn += "-" + VersionMeta
+	if OPVersionMeta != "stable" {
+		vsn += "-" + OPVersionMeta
 	}
 	if len(gitCommit) >= 8 {
 		vsn += "-" + gitCommit[:8]
@@ -60,7 +81,7 @@ func VersionWithCommit(gitCommit, gitDate string) string {
 	if len(gitCommit) >= 8 {
 		vsn += "-" + gitCommit[:8]
 	}
-	if (VersionMeta != "stable") && (gitDate != "") {
+	if (OPVersionMeta != "stable") && (gitDate != "") {
 		vsn += "-" + gitDate
 	}
 	return vsn


### PR DESCRIPTION
**Description**
There are now two versions stored in params/version.go. One for
upstream geth and one for op-geth. We keep the upstream version
in the source to make it easier to determine the base version.

We retain a unique versioning system for op-geth because we do
not expect a 1:1 correspondence between our versions & upstream
versions.

**Additional context**
This still requires some work to actually cut the release.

**Metadata**
- Fixes ENG-2382
